### PR TITLE
Prevent the \ character causing the version to wrap the next line

### DIFF
--- a/changelog/@unreleased/pr-9.v2.yml
+++ b/changelog/@unreleased/pr-9.v2.yml
@@ -1,5 +1,5 @@
 type: fix
 fix:
-  description: sync with develop
+  description: Prevent the \ character causing the version to wrap the next line
   links:
   - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/9

--- a/changelog/@unreleased/pr-9.v2.yml
+++ b/changelog/@unreleased/pr-9.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: sync with develop
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/9

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
@@ -66,7 +66,7 @@ GROUP_PART=[^.:=\ \n\t\f\\] | "\\ "
 
 <WAITING_VALUE> {WHITE_SPACE}+                              { yybegin(WAITING_VALUE); return TokenType.WHITE_SPACE; }
 
-<WAITING_VALUE> {VALUE_CHARACTER}*                          { yybegin(YYINITIAL); return VersionPropsTypes.VERSION; }
+<WAITING_VALUE> {VALUE_CHARACTER}+                          { yybegin(YYINITIAL); return VersionPropsTypes.VERSION; }
 
 ({CRLF}|{WHITE_SPACE})+                                     { yybegin(YYINITIAL); return TokenType.WHITE_SPACE; }
 

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
@@ -33,8 +33,7 @@ import com.intellij.psi.TokenType;
 
 CRLF=\R
 WHITE_SPACE=[\ \n\t\f]
-FIRST_VALUE_CHARACTER=[^ \n\f\\] | "\\"{CRLF} | "\\".
-VALUE_CHARACTER=[^\n\f\\] | "\\"{CRLF} | "\\".
+VALUE_CHARACTER=[^ \n\f\\] | "\\"{CRLF} | "\\".
 END_OF_LINE_COMMENT=("#"|"!")[^\r\n]*
 COLON=[:]
 EQUALS=[=]
@@ -67,7 +66,7 @@ GROUP_PART=[^.:=\ \n\t\f\\] | "\\ "
 
 <WAITING_VALUE> {WHITE_SPACE}+                              { yybegin(WAITING_VALUE); return TokenType.WHITE_SPACE; }
 
-<WAITING_VALUE> {FIRST_VALUE_CHARACTER}{VALUE_CHARACTER}*   { yybegin(YYINITIAL); return VersionPropsTypes.VERSION; }
+<WAITING_VALUE> {VALUE_CHARACTER}*                          { yybegin(YYINITIAL); return VersionPropsTypes.VERSION; }
 
 ({CRLF}|{WHITE_SPACE})+                                     { yybegin(YYINITIAL); return TokenType.WHITE_SPACE; }
 

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
@@ -33,19 +33,18 @@ import com.intellij.psi.TokenType;
 
 CRLF=\R
 WHITE_SPACE=[\ \n\t\f]
-VALUE_CHARACTER=[^ \n\f\\] | "\\"{CRLF} | "\\".
-END_OF_LINE_COMMENT=("#"|"!")[^\r\n]*
+VALUE_CHARACTER=[^ \n\f]+
 COLON=[:]
 EQUALS=[=]
 DOT=[.]
-KEY_CHARACTER=[^:=\ \n\t\f\\] | "\\ "
-GROUP_PART=[^.:=\ \n\t\f\\] | "\\ "
+KEY_CHARACTER=[^:=\ \n\t\f]+
+GROUP_PART=[^.:=\ \n\t\f]+
+COMMENT=("#")[^\r\n]*
 
-%state WAITING_NAME, WAITING_VERSION, WAITING_VALUE
+%state WAITING_NAME, WAITING_VERSION, WAITING_VALUE, INVALID_VALUE
 
 %%
-
-<YYINITIAL> {END_OF_LINE_COMMENT}                           { yybegin(YYINITIAL); return VersionPropsTypes.COMMENT; }
+<YYINITIAL> {COMMENT}                                       { yybegin(YYINITIAL); return VersionPropsTypes.COMMENT; }
 
 <YYINITIAL> {GROUP_PART}+                                   { yybegin(YYINITIAL); return VersionPropsTypes.GROUP_PART; }
 <YYINITIAL> {DOT}                                           { yybegin(YYINITIAL); return VersionPropsTypes.DOT; }
@@ -66,7 +65,9 @@ GROUP_PART=[^.:=\ \n\t\f\\] | "\\ "
 
 <WAITING_VALUE> {WHITE_SPACE}+                              { yybegin(WAITING_VALUE); return TokenType.WHITE_SPACE; }
 
-<WAITING_VALUE> {VALUE_CHARACTER}+                          { yybegin(YYINITIAL); return VersionPropsTypes.VERSION; }
+<WAITING_VALUE> {VALUE_CHARACTER}+                          { yybegin(INVALID_VALUE); return VersionPropsTypes.VERSION; }
+
+<INVALID_VALUE> [^\n]+                                      { return TokenType.BAD_CHARACTER; }
 
 ({CRLF}|{WHITE_SPACE})+                                     { yybegin(YYINITIAL); return TokenType.WHITE_SPACE; }
 

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
@@ -16,9 +16,15 @@
 package com.palantir.gradle.versions.intellij;
 
 import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.testFramework.UsefulTestCase;
 import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5;
+import com.palantir.gradle.versions.intellij.psi.VersionPropsTypes;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -75,5 +81,103 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
         fixture.complete(CompletionType.BASIC);
         List<String> lookupElementStrings = fixture.getLookupElementStrings();
         UsefulTestCase.assertEmpty(lookupElementStrings);
+    }
+
+    @Test
+    public void test_psi_tree_structure() throws Exception {
+        JavaCodeInsightTestFixture fixture = getFixture();
+        fixture.configureByText("versions.props", "com.palantir.baseline:baseline-error-prone=2.40.2");
+
+        ApplicationManager.getApplication().runReadAction(() -> {
+            PsiFile psiFile = fixture.getFile();
+            Assertions.assertNotNull(psiFile);
+
+            // Get the first property element
+            PsiElement propertyElement = psiFile.getFirstChild();
+            Assertions.assertNotNull(propertyElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.PROPERTY, propertyElement.getNode().getElementType());
+
+            // Get the dependency group
+            PsiElement dependencyGroupElement = propertyElement.getFirstChild();
+            Assertions.assertNotNull(dependencyGroupElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.DEPENDENCY_GROUP,
+                    dependencyGroupElement.getNode().getElementType());
+
+            // Verify the GROUP_PART elements within the dependency group
+            PsiElement[] groupParts = PsiTreeUtil.getChildrenOfType(dependencyGroupElement, PsiElement.class);
+            Assertions.assertNotNull(groupParts);
+            Assertions.assertTrue(groupParts.length >= 5); // Should contain at least com, ., palantir, ., baseline
+            Assertions.assertEquals(
+                    VersionPropsTypes.GROUP_PART, groupParts[0].getNode().getElementType());
+            Assertions.assertEquals("com", groupParts[0].getText());
+            Assertions.assertEquals(
+                    VersionPropsTypes.DOT, groupParts[1].getNode().getElementType());
+            Assertions.assertEquals(".", groupParts[1].getText());
+            Assertions.assertEquals(
+                    VersionPropsTypes.GROUP_PART, groupParts[2].getNode().getElementType());
+            Assertions.assertEquals("palantir", groupParts[2].getText());
+            Assertions.assertEquals(
+                    VersionPropsTypes.DOT, groupParts[3].getNode().getElementType());
+            Assertions.assertEquals(".", groupParts[3].getText());
+            Assertions.assertEquals(
+                    VersionPropsTypes.GROUP_PART, groupParts[4].getNode().getElementType());
+            Assertions.assertEquals("baseline", groupParts[4].getText());
+
+            // Get the colon separating the group and name
+            PsiElement colonElement = dependencyGroupElement.getNextSibling();
+            while (colonElement != null && colonElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
+                colonElement = colonElement.getNextSibling();
+            }
+            Assertions.assertNotNull(colonElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.COLON, colonElement.getNode().getElementType());
+
+            // Get the dependency name
+            PsiElement dependencyNameElement = colonElement.getNextSibling();
+            while (dependencyNameElement != null
+                    && dependencyNameElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
+                dependencyNameElement = dependencyNameElement.getNextSibling();
+            }
+            Assertions.assertNotNull(dependencyNameElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.DEPENDENCY_NAME,
+                    dependencyNameElement.getNode().getElementType());
+
+            // Verify the NAME_KEY element within the dependency name
+            PsiElement nameKeyElement = dependencyNameElement.getFirstChild();
+            Assertions.assertNotNull(nameKeyElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.NAME_KEY, nameKeyElement.getNode().getElementType());
+            Assertions.assertEquals("baseline-error-prone", nameKeyElement.getText());
+
+            // Get the equals sign separating the name and version
+            PsiElement equalsElement = dependencyNameElement.getNextSibling();
+            while (equalsElement != null && equalsElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
+                equalsElement = equalsElement.getNextSibling();
+            }
+            Assertions.assertNotNull(equalsElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.EQUALS, equalsElement.getNode().getElementType());
+
+            // Get the dependency version
+            PsiElement dependencyVersionElement = equalsElement.getNextSibling();
+            while (dependencyVersionElement != null
+                    && dependencyVersionElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
+                dependencyVersionElement = dependencyVersionElement.getNextSibling();
+            }
+            Assertions.assertNotNull(dependencyVersionElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.DEPENDENCY_VERSION,
+                    dependencyVersionElement.getNode().getElementType());
+
+            // Verify the VERSION element within the dependency version
+            PsiElement versionElement = dependencyVersionElement.getFirstChild();
+            Assertions.assertNotNull(versionElement);
+            Assertions.assertEquals(
+                    VersionPropsTypes.VERSION, versionElement.getNode().getElementType());
+            Assertions.assertEquals("2.40.2", versionElement.getText());
+        });
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
@@ -92,20 +92,17 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
             PsiFile psiFile = fixture.getFile();
             Assertions.assertNotNull(psiFile);
 
-            // Get the first property element
             PsiElement propertyElement = psiFile.getFirstChild();
             Assertions.assertNotNull(propertyElement);
             Assertions.assertEquals(
                     VersionPropsTypes.PROPERTY, propertyElement.getNode().getElementType());
 
-            // Get the dependency group
             PsiElement dependencyGroupElement = propertyElement.getFirstChild();
             Assertions.assertNotNull(dependencyGroupElement);
             Assertions.assertEquals(
                     VersionPropsTypes.DEPENDENCY_GROUP,
                     dependencyGroupElement.getNode().getElementType());
 
-            // Verify the GROUP_PART elements within the dependency group
             PsiElement[] groupParts = PsiTreeUtil.getChildrenOfType(dependencyGroupElement, PsiElement.class);
             Assertions.assertNotNull(groupParts);
             Assertions.assertTrue(groupParts.length >= 5); // Should contain at least com, ., palantir, ., baseline
@@ -125,7 +122,6 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
                     VersionPropsTypes.GROUP_PART, groupParts[4].getNode().getElementType());
             Assertions.assertEquals("baseline", groupParts[4].getText());
 
-            // Get the colon separating the group and name
             PsiElement colonElement = dependencyGroupElement.getNextSibling();
             while (colonElement != null && colonElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
                 colonElement = colonElement.getNextSibling();
@@ -134,7 +130,6 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
             Assertions.assertEquals(
                     VersionPropsTypes.COLON, colonElement.getNode().getElementType());
 
-            // Get the dependency name
             PsiElement dependencyNameElement = colonElement.getNextSibling();
             while (dependencyNameElement != null
                     && dependencyNameElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
@@ -145,14 +140,12 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
                     VersionPropsTypes.DEPENDENCY_NAME,
                     dependencyNameElement.getNode().getElementType());
 
-            // Verify the NAME_KEY element within the dependency name
             PsiElement nameKeyElement = dependencyNameElement.getFirstChild();
             Assertions.assertNotNull(nameKeyElement);
             Assertions.assertEquals(
                     VersionPropsTypes.NAME_KEY, nameKeyElement.getNode().getElementType());
             Assertions.assertEquals("baseline-error-prone", nameKeyElement.getText());
 
-            // Get the equals sign separating the name and version
             PsiElement equalsElement = dependencyNameElement.getNextSibling();
             while (equalsElement != null && equalsElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
                 equalsElement = equalsElement.getNextSibling();
@@ -161,7 +154,6 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
             Assertions.assertEquals(
                     VersionPropsTypes.EQUALS, equalsElement.getNode().getElementType());
 
-            // Get the dependency version
             PsiElement dependencyVersionElement = equalsElement.getNextSibling();
             while (dependencyVersionElement != null
                     && dependencyVersionElement.getNode().getElementType() == TokenType.WHITE_SPACE) {
@@ -172,7 +164,6 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
                     VersionPropsTypes.DEPENDENCY_VERSION,
                     dependencyVersionElement.getNode().getElementType());
 
-            // Verify the VERSION element within the dependency version
             PsiElement versionElement = dependencyVersionElement.getFirstChild();
             Assertions.assertNotNull(versionElement);
             Assertions.assertEquals(


### PR DESCRIPTION
## Before this PR
Previously if you finished a line in version.props with `\` it would wrap the version to include the following line

## After this PR
Updated the grammar such that version versions do not wrap to the following line so the `\` can be safely used
