### PR TITLE
Mark and pin the latest version during autocomplete suggestion

### DIFF
--- a/changelog/@unreleased/pr-11.v2.yml
+++ b/changelog/@unreleased/pr-11.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Mark and pin the latest version during autocomplete suggestion
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/11

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/DependencyVersion.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/DependencyVersion.java
@@ -22,8 +22,13 @@ import org.immutables.value.Value;
 public abstract class DependencyVersion {
     protected abstract String version();
 
-    public static ImmutableDependencyVersion of(String version) {
-        return ImmutableDependencyVersion.builder().version(version).build();
+    protected abstract Boolean isLatest();
+
+    public static ImmutableDependencyVersion of(String version, Boolean isLatest) {
+        return ImmutableDependencyVersion.builder()
+                .version(version)
+                .isLatest(isLatest)
+                .build();
     }
 
     @Override

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
@@ -23,6 +23,7 @@ import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.util.ProcessingContext;
 import com.palantir.gradle.versions.intellij.psi.VersionPropsTypes;
@@ -53,5 +54,10 @@ public class FolderCompletionContributor extends CompletionContributor {
                         .forEach(resultSet::addElement);
             }
         });
+    }
+
+    @Override
+    public final boolean invokeAutoPopup(PsiElement position, char typeChar) {
+        return typeChar == '=';
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
@@ -58,6 +58,6 @@ public class FolderCompletionContributor extends CompletionContributor {
 
     @Override
     public final boolean invokeAutoPopup(PsiElement position, char typeChar) {
-        return typeChar == '=';
+        return typeChar == ':';
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -94,8 +94,9 @@ public class RepositoryExplorer {
 
             Metadata metadata = xmlMapper.readValue(content, Metadata.class);
             if (metadata.versioning() != null && metadata.versioning().versions() != null) {
+                String latest = metadata.versioning().latest();
                 for (String version : metadata.versioning().versions()) {
-                    versions.add(DependencyVersion.of(version));
+                    versions.add(DependencyVersion.of(version, latest.equals(version)));
                 }
             }
         } catch (Exception e) {

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 public class VersionCompletionContributor extends CompletionContributor {
 
     private static final Logger log = LoggerFactory.getLogger(VersionCompletionContributor.class);
-    private char previousChar = '\0';
 
     VersionCompletionContributor() {
         extend(

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
@@ -83,8 +83,6 @@ public class VersionCompletionContributor extends CompletionContributor {
 
     @Override
     public final boolean invokeAutoPopup(PsiElement position, char typeChar) {
-        boolean shouldInvoke = (previousChar == '=' && typeChar == ' ');
-        previousChar = typeChar;
-        return shouldInvoke;
+        return typeChar == '=';
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
@@ -20,9 +20,11 @@ import com.intellij.codeInsight.completion.CompletionParameters;
 import com.intellij.codeInsight.completion.CompletionProvider;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.completion.CompletionType;
+import com.intellij.codeInsight.completion.PrioritizedLookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.ProcessingContext;
 import com.palantir.gradle.versions.intellij.psi.VersionPropsDependencyVersion;
@@ -62,7 +64,13 @@ public class VersionCompletionContributor extends CompletionContributor {
                                 .map(RepositoryExplorer::new)
                                 .flatMap(repositoryExplorer ->
                                         repositoryExplorer.getVersions(group, dependencyPackage).stream())
-                                .map(LookupElementBuilder::create)
+                                .map(version -> version.isLatest()
+                                        ? PrioritizedLookupElement.withPriority(
+                                        LookupElementBuilder.create(version)
+                                                .withTypeText("Latest", true)
+                                                .withLookupString("latest"),
+                                        Double.MAX_VALUE)
+                                        : LookupElementBuilder.create(version))
                                 .forEach(resultSet::addElement);
                     }
                 });
@@ -70,5 +78,10 @@ public class VersionCompletionContributor extends CompletionContributor {
 
     private VersionPropsProperty findParentProperty(VersionPropsDependencyVersion versionElement) {
         return versionElement == null ? null : PsiTreeUtil.getParentOfType(versionElement, VersionPropsProperty.class);
+    }
+
+    @Override
+    public final boolean invokeAutoPopup(PsiElement position, char typeChar) {
+        return typeChar == '=';
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 public class VersionCompletionContributor extends CompletionContributor {
 
     private static final Logger log = LoggerFactory.getLogger(VersionCompletionContributor.class);
+    private char previousChar = '\0';
 
     VersionCompletionContributor() {
         extend(
@@ -82,6 +83,8 @@ public class VersionCompletionContributor extends CompletionContributor {
 
     @Override
     public final boolean invokeAutoPopup(PsiElement position, char typeChar) {
-        return typeChar == '=';
+        boolean shouldInvoke = (previousChar == '=' && typeChar == ' ');
+        previousChar = typeChar;
+        return shouldInvoke;
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionCompletionContributor.java
@@ -66,10 +66,10 @@ public class VersionCompletionContributor extends CompletionContributor {
                                         repositoryExplorer.getVersions(group, dependencyPackage).stream())
                                 .map(version -> version.isLatest()
                                         ? PrioritizedLookupElement.withPriority(
-                                        LookupElementBuilder.create(version)
-                                                .withTypeText("Latest", true)
-                                                .withLookupString("latest"),
-                                        Double.MAX_VALUE)
+                                                LookupElementBuilder.create(version)
+                                                        .withTypeText("Latest", true)
+                                                        .withLookupString("latest"),
+                                                Double.MAX_VALUE)
                                         : LookupElementBuilder.create(version))
                                 .forEach(resultSet::addElement);
                     }


### PR DESCRIPTION
## Before this PR
It has been very hard to know what the latest version of a particular package is when using auto complete

## After this PR
Now the latest version is pinned and labeled, you can also find the latest version by starting to type `latest`

I have also made it such that the autocompletes popup as soon as = has been pressed so you don't need to start typing the version 

## Possible downsides?
I could not find a way to **always** pin the latest version so say the latest is 2.0.0 and you start typing 1. it will not suggest 2.0.0
