### PR TITLE
fix missing import

### DIFF
--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: fix missing import
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/22

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
@@ -28,6 +28,7 @@ import com.intellij.testFramework.fixtures.JavaCodeInsightTestFixture;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5;
 import com.palantir.gradle.versions.intellij.psi.VersionPropsTypes;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTestCase5 {


### PR DESCRIPTION
## Before this PR
All builds where breaking

## After this PR
Fixed builds by importing `import org.junit.jupiter.api.Assertions;`

Not sure how a breaking change like that managed to merge but this should fix it


