### PR TITLE
ignore unknown

### DIFF
--- a/changelog/@unreleased/pr-25.v2.yml
+++ b/changelog/@unreleased/pr-25.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ignore unknown
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/25

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Metadata.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Metadata.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.versions.intellij;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -27,6 +28,7 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableMetadata.class)
 @JsonSerialize(as = ImmutableMetadata.class)
 @JsonRootName("metadata")
+@JsonIgnoreProperties(ignoreUnknown = true)
 interface Metadata {
     @Value.Parameter
     @JacksonXmlElementWrapper(useWrapping = false)

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -116,7 +116,7 @@ public class RepositoryExplorer {
                 }
             }
         } catch (Exception e) {
-            log.debug("Failed to parse maven-metadata.xml", e);
+            log.error("Failed to parse maven-metadata.xml", e);
         }
         return versions;
     }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Versioning.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Versioning.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.versions.intellij;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
@@ -25,6 +26,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableVersioning.class)
 @JsonSerialize(as = ImmutableVersioning.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 interface Versioning {
     @Value.Parameter
     @JacksonXmlElementWrapper(useWrapping = false)


### PR DESCRIPTION
## Before this PR
We would silently fail to parse metadata for versions as sometime the metadata contains extra fields

## After this PR
we know ignore unknown fields so that it does not fail in this way - I have also made the message error level and not debug so it is no longer silently failing
