### PR TITLE
Settings Page

### DIFF
--- a/changelog/@unreleased/pr-27.v2.yml
+++ b/changelog/@unreleased/pr-27.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Settings Page
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/27

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsFileListener.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsFileListener.java
@@ -73,7 +73,7 @@ public final class VersionPropsFileListener implements AsyncFileListener {
             @Override
             public void afterVfsChange() {
                 projectsAffected.forEach(project -> {
-                    VersionPropsSettings settings = VersionPropsSettings.getInstance(project);
+                    VersionPropsProjectSettings settings = VersionPropsProjectSettings.getInstance(project);
                     if (!settings.isEnabled()) {
                         return;
                     }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsFileListener.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsFileListener.java
@@ -73,6 +73,11 @@ public final class VersionPropsFileListener implements AsyncFileListener {
             @Override
             public void afterVfsChange() {
                 projectsAffected.forEach(project -> {
+                    VersionPropsSettings settings = VersionPropsSettings.getInstance(project);
+                    if (!settings.isEnabled()) {
+                        return;
+                    }
+
                     if (hasBuildSrc(project)) {
                         runTaskThenRefresh(project);
                     } else {

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsProjectSettings.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsProjectSettings.java
@@ -18,43 +18,26 @@ package com.palantir.gradle.versions.intellij;
 
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.Service.Level;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.Nullable;
 
+@Service(Level.PROJECT)
 @com.intellij.openapi.components.State(
         name = "ProjectSettings",
         storages = {@Storage("gcv-plugin-settings.xml")})
-@Service(Service.Level.PROJECT)
 public final class VersionPropsProjectSettings implements PersistentStateComponent<VersionPropsProjectSettings.State> {
 
-    public enum EnabledState {
-        UNKNOWN,
-        ENABLED,
-        DISABLED
-    }
-
     public static final class State {
-        // Using an enum like this ensure that the file is created in .idea allowing for end users to configure it for
-        // all users
-        private EnabledState enabled = EnabledState.UNKNOWN;
+        private boolean enabled = true;
 
-        public void setEnabled(@Nullable String enabledStr) {
-            if (enabledStr == null) {
-                enabled = EnabledState.UNKNOWN;
-            } else if (Boolean.valueOf(enabledStr)) {
-                enabled = EnabledState.ENABLED;
-            } else {
-                enabled = EnabledState.DISABLED;
-            }
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
         }
 
-        public String getEnabled() {
-            return switch (enabled) {
-                case ENABLED -> "true";
-                case DISABLED -> "false";
-                default -> null;
-            };
+        public boolean getEnabled() {
+            return this.enabled;
         }
     }
 
@@ -72,14 +55,10 @@ public final class VersionPropsProjectSettings implements PersistentStateCompone
     }
 
     public boolean isEnabled() {
-        return state.enabled.equals(EnabledState.ENABLED);
+        return state.enabled;
     }
 
     public void setEnabled(boolean enabled) {
-        setEnabled(enabled ? EnabledState.ENABLED : EnabledState.DISABLED);
-    }
-
-    public void setEnabled(EnabledState enabled) {
         state.enabled = enabled;
     }
 

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsProjectSettings.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsProjectSettings.java
@@ -20,15 +20,13 @@ import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
-import java.util.ArrayList;
-import java.util.List;
 import org.jetbrains.annotations.Nullable;
 
 @com.intellij.openapi.components.State(
-        name = "GradleConsistentVersionsSettings",
-        storages = {@Storage("gradle-consistent-versions-plugin-settings.xml")})
+        name = "ProjectSettings",
+        storages = {@Storage("gcv-plugin-settings.xml")})
 @Service(Service.Level.PROJECT)
-public final class VersionPropsSettings implements PersistentStateComponent<VersionPropsSettings.State> {
+public final class VersionPropsProjectSettings implements PersistentStateComponent<VersionPropsProjectSettings.State> {
 
     public enum EnabledState {
         UNKNOWN,
@@ -37,8 +35,9 @@ public final class VersionPropsSettings implements PersistentStateComponent<Vers
     }
 
     public static final class State {
+        // Using an enum like this ensure that the file is created in .idea allowing for end users to configure it for
+        // all users
         private EnabledState enabled = EnabledState.UNKNOWN;
-        private List<String> mavenRepositories = new ArrayList<>();
 
         public void setEnabled(@Nullable String enabledStr) {
             if (enabledStr == null) {
@@ -56,19 +55,6 @@ public final class VersionPropsSettings implements PersistentStateComponent<Vers
                 case DISABLED -> "false";
                 default -> null;
             };
-        }
-
-        @Override
-        public String toString() {
-            return "State{" + "enabled=" + enabled + ", mavenRepositories=" + mavenRepositories + '}';
-        }
-
-        public List<String> getMavenRepositories() {
-            return mavenRepositories;
-        }
-
-        public void setMavenRepositories(List<String> mavenRepositories) {
-            this.mavenRepositories = mavenRepositories;
         }
     }
 
@@ -97,15 +83,7 @@ public final class VersionPropsSettings implements PersistentStateComponent<Vers
         state.enabled = enabled;
     }
 
-    public List<String> getMavenRepositories() {
-        return state.getMavenRepositories();
-    }
-
-    public void setMavenRepositories(List<String> mavenRepositories) {
-        state.setMavenRepositories(mavenRepositories);
-    }
-
-    public static VersionPropsSettings getInstance(Project project) {
-        return project.getService(VersionPropsSettings.class);
+    public static VersionPropsProjectSettings getInstance(Project project) {
+        return project.getService(VersionPropsProjectSettings.class);
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsSettings.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsSettings.java
@@ -1,0 +1,111 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions.intellij;
+
+import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.project.Project;
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
+
+@com.intellij.openapi.components.State(
+        name = "GradleConsistentVersionsSettings",
+        storages = {@Storage("gradle-consistent-versions-plugin-settings.xml")})
+@Service(Service.Level.PROJECT)
+public final class VersionPropsSettings implements PersistentStateComponent<VersionPropsSettings.State> {
+
+    public enum EnabledState {
+        UNKNOWN,
+        ENABLED,
+        DISABLED
+    }
+
+    public static final class State {
+        private EnabledState enabled = EnabledState.UNKNOWN;
+        private List<String> mavenRepositories = new ArrayList<>();
+
+        public void setEnabled(@Nullable String enabledStr) {
+            if (enabledStr == null) {
+                enabled = EnabledState.UNKNOWN;
+            } else if (Boolean.valueOf(enabledStr)) {
+                enabled = EnabledState.ENABLED;
+            } else {
+                enabled = EnabledState.DISABLED;
+            }
+        }
+
+        public String getEnabled() {
+            return switch (enabled) {
+                case ENABLED -> "true";
+                case DISABLED -> "false";
+                default -> null;
+            };
+        }
+
+        @Override
+        public String toString() {
+            return "State{" + "enabled=" + enabled + ", mavenRepositories=" + mavenRepositories + '}';
+        }
+
+        public List<String> getMavenRepositories() {
+            return mavenRepositories;
+        }
+
+        public void setMavenRepositories(List<String> mavenRepositories) {
+            this.mavenRepositories = mavenRepositories;
+        }
+    }
+
+    private State state = new State();
+
+    @Nullable
+    @Override
+    public State getState() {
+        return state;
+    }
+
+    @Override
+    public void loadState(State status) {
+        this.state = status;
+    }
+
+    public boolean isEnabled() {
+        return state.enabled.equals(EnabledState.ENABLED);
+    }
+
+    public void setEnabled(boolean enabled) {
+        setEnabled(enabled ? EnabledState.ENABLED : EnabledState.DISABLED);
+    }
+
+    public void setEnabled(EnabledState enabled) {
+        state.enabled = enabled;
+    }
+
+    public List<String> getMavenRepositories() {
+        return state.getMavenRepositories();
+    }
+
+    public void setMavenRepositories(List<String> mavenRepositories) {
+        state.setMavenRepositories(mavenRepositories);
+    }
+
+    public static VersionPropsSettings getInstance(Project project) {
+        return project.getService(VersionPropsSettings.class);
+    }
+}

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsSettingsPage.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsSettingsPage.java
@@ -1,0 +1,71 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions.intellij;
+
+import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.Nullable;
+
+public final class VersionPropsSettingsPage implements Configurable {
+    private JCheckBox enabledCheckbox;
+
+    private final VersionPropsSettings settings;
+
+    public VersionPropsSettingsPage(Project project) {
+        settings = VersionPropsSettings.getInstance(project);
+    }
+
+    @Nls
+    @Override
+    public String getDisplayName() {
+        return "Gradle Consistent Versions";
+    }
+
+    @Nullable
+    @Override
+    public JComponent createComponent() {
+        JPanel rootPanel = new JPanel();
+        enabledCheckbox = new JCheckBox("Enable gradle-consistent-versions plugin");
+        rootPanel.add(enabledCheckbox);
+        return rootPanel;
+    }
+
+    @Override
+    public boolean isModified() {
+        return enabledCheckbox.isSelected() != settings.isEnabled();
+    }
+
+    @Override
+    public void apply() throws ConfigurationException {
+        settings.setEnabled(enabledCheckbox.isSelected());
+    }
+
+    @Override
+    public void reset() {
+        enabledCheckbox.setSelected(settings.isEnabled());
+    }
+
+    @Override
+    public void disposeUIResources() {
+        // No resources to dispose
+    }
+}

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsSettingsPage.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsSettingsPage.java
@@ -28,10 +28,10 @@ import org.jetbrains.annotations.Nullable;
 public final class VersionPropsSettingsPage implements Configurable {
     private JCheckBox enabledCheckbox;
 
-    private final VersionPropsSettings settings;
+    private final VersionPropsProjectSettings settings;
 
     public VersionPropsSettingsPage(Project project) {
-        settings = VersionPropsSettings.getInstance(project);
+        settings = VersionPropsProjectSettings.getInstance(project);
     }
 
     @Nls

--- a/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,8 @@
   <depends>org.jetbrains.plugins.gradle</depends>
 
   <extensions defaultExtensionNs="com.intellij">
+    <projectService serviceImplementation="com.palantir.gradle.versions.intellij.VersionPropsSettings"/>
+    <projectConfigurable instance="com.palantir.gradle.versions.intellij.VersionPropsSettingsPage" displayName="Gradle Consistent Versions" parentId="tools"/>
     <fileType name="VersionProps File" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsFileType" fieldName="INSTANCE"
               language="VersionProps" fileNames="versions.props"/>
     <lang.parserDefinition language="VersionProps" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsParserDefinition"/>

--- a/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -11,8 +11,7 @@
   <depends>org.jetbrains.plugins.gradle</depends>
 
   <extensions defaultExtensionNs="com.intellij">
-    <projectService serviceImplementation="com.palantir.gradle.versions.intellij.VersionPropsSettings"/>
-    <projectConfigurable instance="com.palantir.gradle.versions.intellij.VersionPropsSettingsPage" displayName="Gradle Consistent Versions" parentId="tools"/>
+    <projectConfigurable instance="com.palantir.gradle.versions.intellij.VersionPropsSettingsPage" displayName="Gradle Consistent Versions" id="VersionPropsSettingsPage"/>
     <fileType name="VersionProps File" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsFileType" fieldName="INSTANCE"
               language="VersionProps" fileNames="versions.props"/>
     <lang.parserDefinition language="VersionProps" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsParserDefinition"/>


### PR DESCRIPTION
## Before this PR
No way to enable the plugin running wVL on a project by project level

## After this PR
We now have a project level setting under the `tools` section that allows you to disable the feature

## Possible downsides?
Might result in users turning off the feature then not switching it back on

