### PR TITLE
Create file system cache

### DIFF
--- a/changelog/@unreleased/pr-32.v2.yml
+++ b/changelog/@unreleased/pr-32.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Create file system cache
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/32

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
@@ -28,6 +28,7 @@ import com.intellij.psi.tree.IElementType;
 import com.intellij.util.ProcessingContext;
 import com.palantir.gradle.versions.intellij.psi.VersionPropsTypes;
 import java.util.List;
+import java.util.Objects;
 
 public class FolderCompletionContributor extends CompletionContributor {
 
@@ -53,6 +54,7 @@ public class FolderCompletionContributor extends CompletionContributor {
 
                 repositories.stream()
                         .flatMap(repo -> FILE_CACHE.suggestions(repo, group).stream())
+                        .filter(Objects::nonNull)
                         .map(suggestion -> LookupElementBuilder.create(Folder.of(suggestion)))
                         .forEach(resultSet::addElement);
             }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryFileCache.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryFileCache.java
@@ -1,0 +1,86 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions.intellij;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RepositoryFileCache {
+    private static final Logger log = LoggerFactory.getLogger(RepositoryFileCache.class);
+
+    private static final String CACHE_PATH = System.getProperty("user.home") + "/.gcv-cache";
+
+    private static final Map<String, Set<String>> cache = new HashMap<>();
+
+    public final void syncCache(String repoUrl, Set<String> packages) {
+        Set<String> existingPackages = cache.get(repoUrl);
+        boolean hasChanges = false;
+
+        if (existingPackages == null) {
+            existingPackages = new HashSet<>(packages);
+            cache.put(repoUrl, existingPackages);
+            hasChanges = true;
+        } else {
+            hasChanges = existingPackages.addAll(packages);
+        }
+
+        if (hasChanges) {
+            writeCacheToFile(repoUrl, existingPackages);
+        }
+    }
+
+    private void writeCacheToFile(String repoUrl, Set<String> packages) {
+        try {
+            String hashedFileName = hashRepoUrl(repoUrl);
+            Path cacheFilePath = Paths.get(CACHE_PATH, hashedFileName);
+
+            if (!Files.exists(cacheFilePath.getParent())) {
+                Files.createDirectories(cacheFilePath.getParent());
+            }
+
+            Files.write(cacheFilePath, packages, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+        } catch (IOException | NoSuchAlgorithmException e) {
+            log.error("Failed to write cache to file", e);
+        }
+    }
+
+    private String hashRepoUrl(String repoUrl) throws NoSuchAlgorithmException {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(repoUrl.getBytes());
+        StringBuilder hexString = new StringBuilder(2 * hash.length);
+        for (byte b : hash) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryFileCache.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryFileCache.java
@@ -105,7 +105,6 @@ public class RepositoryFileCache {
     }
 
     private String modifyPackage(String repoUrl, String packageName) {
-        System.out.println(packageName);
         String urlString = repoUrl + packageName.replaceAll("\\.", "/") + "/maven-metadata.xml";
         try {
             URL url = new URL(urlString);

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryFileCacheTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryFileCacheTest.java
@@ -1,0 +1,59 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions.intellij;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RepositoryFileCacheTest {
+
+    private RepositoryFileCache cache;
+
+    @BeforeEach
+    public void beforeEach() {
+        cache = new RepositoryFileCache();
+    }
+
+    @Test
+    public void can_add_and_get_suggestions() {
+        String repoUrl = "https://repo1.maven.org/maven2/";
+        Set<String> packages = new HashSet<>();
+        packages.add("com.palantir");
+        packages.add("com.fasterxml");
+
+        cache.syncCache(repoUrl, packages);
+
+        Set<String> cachedPackages = cache.suggestions(repoUrl, DependencyGroup.fromString("com"));
+        Assertions.assertThat(cachedPackages).contains("palantir");
+        Assertions.assertThat(cachedPackages).contains("fasterxml");
+    }
+
+    @Test
+    public void correctly_modify_full_packages() {
+        String repoUrl = "https://repo1.maven.org/maven2/";
+        Set<String> packages = new HashSet<>();
+        packages.add("com.palantir.baseline.baseline-error-prone");
+
+        cache.syncCache(repoUrl, packages);
+
+        Set<String> cachedPackages = cache.suggestions(repoUrl, DependencyGroup.fromString("com"));
+        Assertions.assertThat(cachedPackages).contains("palantir.baseline:baseline-error-prone");
+    }
+}

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryFileCacheTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryFileCacheTest.java
@@ -32,7 +32,7 @@ public class RepositoryFileCacheTest {
     }
 
     @Test
-    public void can_add_and_get_suggestions() {
+    public void can_add_and_get_suggestions() throws InterruptedException {
         String repoUrl = "https://repo1.maven.org/maven2/";
         Set<String> packages = new HashSet<>();
         packages.add("com.palantir");
@@ -40,18 +40,24 @@ public class RepositoryFileCacheTest {
 
         cache.syncCache(repoUrl, packages);
 
+        // sleep as adding to the cache can take some time
+        Thread.sleep(2000);
+
         Set<String> cachedPackages = cache.suggestions(repoUrl, DependencyGroup.fromString("com"));
         Assertions.assertThat(cachedPackages).contains("palantir");
         Assertions.assertThat(cachedPackages).contains("fasterxml");
     }
 
     @Test
-    public void correctly_modify_full_packages() {
+    public void correctly_modify_full_packages() throws InterruptedException {
         String repoUrl = "https://repo1.maven.org/maven2/";
         Set<String> packages = new HashSet<>();
         packages.add("com.palantir.baseline.baseline-error-prone");
 
         cache.syncCache(repoUrl, packages);
+
+        // sleep as adding to the cache can take some time
+        Thread.sleep(2000);
 
         Set<String> cachedPackages = cache.suggestions(repoUrl, DependencyGroup.fromString("com"));
         Assertions.assertThat(cachedPackages).contains("palantir.baseline:baseline-error-prone");


### PR DESCRIPTION
## Before this PR
We had no long term cache so between runs we would lose any information gathered from the remote repos 

## After this PR
Now the plugin builds a user by user local cache similar to the gradle cache, this is better than just using the gradle cache as we have full control and can mark which repos packages are associated with 
==COMMIT_MSG==
Create file system cache
==COMMIT_MSG==

## Possible downsides?
The plugin now creates this cache which could become very large over time.

So that we can determine if a package is complete (i.e. add the ':') we have to make a lot of calls to check if `maven-metadata` exists, this is only done once per completion but still this might be a bit hard on the remote repos. Annoyingly packages are not always on the same level so we cannot just check the first folder.

