### PR TITLE
Cache is loaded on first instance and on project refresh

### DIFF
--- a/changelog/@unreleased/pr-45.v2.yml
+++ b/changelog/@unreleased/pr-45.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Cache is loaded on first instance and on project refresh
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/45

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
@@ -22,7 +22,6 @@ import com.intellij.codeInsight.completion.CompletionProvider;
 import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.openapi.externalSystem.service.notification.ExternalSystemProgressNotificationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.psi.PsiElement;
@@ -32,14 +31,9 @@ import com.palantir.gradle.versions.intellij.psi.VersionPropsTypes;
 
 public class FolderCompletionContributor extends CompletionContributor {
 
-    private final GradleCacheExplorer gradleCacheExplorer = new GradleCacheExplorer();
-
     private final RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
 
     public FolderCompletionContributor() {
-        // We add listener at this stage so that we can invalidate the cache when the gradle project refreshed
-        ExternalSystemProgressNotificationManager.getInstance()
-                .addNotificationListener(new InvalidateCacheOnGradleProjectRefresh(gradleCacheExplorer));
         cacheCompletion(VersionPropsTypes.GROUP_PART);
         cacheCompletion(VersionPropsTypes.NAME_KEY);
         remoteCompletion(VersionPropsTypes.GROUP_PART);
@@ -74,7 +68,9 @@ public class FolderCompletionContributor extends CompletionContributor {
 
                 Project project = parameters.getOriginalFile().getProject();
 
-                gradleCacheExplorer.getCompletions(RepositoryLoader.loadRepositories(project), group).stream()
+                GradleCacheExplorer.getInstance()
+                        .getCompletions(RepositoryLoader.loadRepositories(project), group)
+                        .stream()
                         .map(suggestion -> LookupElementBuilder.create(GroupPartOrPackageName.of(suggestion)))
                         .forEach(resultSet::addElement);
             }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
@@ -63,7 +63,7 @@ public class GradleCacheExplorer {
         }
 
         stopWatch.stop();
-        log.warn("Cache parsing time: {} ms", stopWatch.getTime());
+        log.debug("Cache parsing time: {} ms", stopWatch.getTime());
 
         return results.stream()
                 .filter(result -> result.startsWith(parsedInput))

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.versions.intellij;
 
+import com.google.common.base.Stopwatch;
 import com.intellij.openapi.application.ApplicationManager;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -29,7 +30,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.time.StopWatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,8 +48,7 @@ public class GradleCacheExplorer {
     }
 
     public final Set<String> getCompletions(Set<String> repoUrls, DependencyGroup input) {
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
+        Stopwatch stopWatch = Stopwatch.createStarted();
 
         String parsedInput = String.join(".", input.parts());
 
@@ -63,7 +62,7 @@ public class GradleCacheExplorer {
         }
 
         stopWatch.stop();
-        log.debug("Cache parsing time: {} ms", stopWatch.getTime());
+        log.debug("Completion matching time: {} ms", stopWatch.elapsed().toMillis());
 
         return results.stream()
                 .filter(result -> result.startsWith(parsedInput))

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/LoadCacheOnGradleProjectRefresh.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/LoadCacheOnGradleProjectRefresh.java
@@ -24,21 +24,15 @@ import org.jetbrains.plugins.gradle.util.GradleConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class InvalidateCacheOnGradleProjectRefresh implements ExternalSystemTaskNotificationListener {
-    private static final Logger log = LoggerFactory.getLogger(InvalidateCacheOnGradleProjectRefresh.class);
-
-    private final GradleCacheExplorer gradleCacheExplorer;
-
-    public InvalidateCacheOnGradleProjectRefresh(GradleCacheExplorer gradleCacheExplorer) {
-        this.gradleCacheExplorer = gradleCacheExplorer;
-    }
+public class LoadCacheOnGradleProjectRefresh implements ExternalSystemTaskNotificationListener {
+    private static final Logger log = LoggerFactory.getLogger(LoadCacheOnGradleProjectRefresh.class);
 
     @Override
     public final void onSuccess(ExternalSystemTaskId id) {
         if (GradleConstants.SYSTEM_ID.equals(id.getProjectSystemId())
                 && id.getType() == ExternalSystemTaskType.RESOLVE_PROJECT) {
-            log.info("Gradle project refresh finished");
-            gradleCacheExplorer.invalidateCache();
+            log.debug("Gradle project refresh finished");
+            GradleCacheExplorer.getInstance().loadCache();
         }
     }
 

--- a/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -10,6 +10,11 @@
   <depends>com.intellij.modules.platform</depends>
   <depends>org.jetbrains.plugins.gradle</depends>
 
+  <applicationListeners>
+    <listener class="com.palantir.gradle.versions.intellij.LoadCacheOnGradleProjectRefresh"
+              topic="com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener"/>
+  </applicationListeners>
+
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.palantir.gradle.versions.intellij.VersionPropsSettingsPage" displayName="Gradle Consistent Versions" id="VersionPropsSettingsPage"/>
     <fileType name="VersionProps File" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsFileType" fieldName="INSTANCE"
@@ -24,5 +29,7 @@
     <lang.commenter language="VersionProps" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsCommenter"/>
     <vfs.asyncListener implementation="com.palantir.gradle.versions.intellij.VersionPropsFileListener"/>
     <annotator language="VersionProps" implementationClass="com.palantir.gradle.versions.intellij.CommentAnnotator" />
+    <externalSystemTaskNotificationListener implementation="com.palantir.gradle.versions.intellij.LoadCacheOnGradleProjectRefresh" />
+    <applicationService serviceImplementation="com.palantir.gradle.versions.intellij.GradleCacheExplorer" />
   </extensions>
 </idea-plugin>

--- a/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -10,11 +10,6 @@
   <depends>com.intellij.modules.platform</depends>
   <depends>org.jetbrains.plugins.gradle</depends>
 
-  <applicationListeners>
-    <listener class="com.palantir.gradle.versions.intellij.LoadCacheOnGradleProjectRefresh"
-              topic="com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener"/>
-  </applicationListeners>
-
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.palantir.gradle.versions.intellij.VersionPropsSettingsPage" displayName="Gradle Consistent Versions" id="VersionPropsSettingsPage"/>
     <fileType name="VersionProps File" implementationClass="com.palantir.gradle.versions.intellij.VersionPropsFileType" fieldName="INSTANCE"

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
@@ -42,25 +42,21 @@ class GradleCacheExplorerTest {
 
     @Test
     void test_gets_valid_urls_only() {
-        Set<String> projectUrls = Set.of("https://repo.maven.apache.org/maven2/", "https://jcenter.bintray.com/");
-
         assertThat(explorer.isValidResourceUrl(
-                        projectUrls, "https://repo.maven.apache.org/maven2/com/example/artifact/1.0/artifact-1.0.pom"))
+                        "https://repo.maven.apache.org/maven2/com/example/artifact/1.0/artifact-1.0.pom"))
                 .as("because the URL is from a known valid repository and ends with .pom")
                 .isTrue();
 
-        assertThat(explorer.isValidResourceUrl(
-                        projectUrls, "https://jcenter.bintray.com/com/example/artifact/1.0/artifact-1.0.jar"))
+        assertThat(explorer.isValidResourceUrl("https://jcenter.bintray.com/com/example/artifact/1.0/artifact-1.0.jar"))
                 .as("because the URL is from a known valid repository and ends with .jar")
                 .isTrue();
 
-        assertThat(explorer.isValidResourceUrl(
-                        projectUrls, "https://example.com/com/example/artifact/1.0/artifact-1.0.pom"))
-                .as("because the URL is not from a known valid repository")
+        assertThat(explorer.isValidResourceUrl("example.com/com/example/artifact/1.0/artifact-1.0.pom"))
+                .as("because the URL is not a valid URL")
                 .isFalse();
 
         assertThat(explorer.isValidResourceUrl(
-                        projectUrls, "https://repo.maven.apache.org/maven2/com/example/artifact/1.0/artifact-1.0.txt"))
+                        "https://repo.maven.apache.org/maven2/com/example/artifact/1.0/artifact-1.0.txt"))
                 .as("because the URL ends with an invalid extension")
                 .isFalse();
     }


### PR DESCRIPTION
## Before this PR
We loading the cache at completion time so closing a completion could create an empty cache that would not be reloaded till the cache was invalidated

## After this PR
Now the cache is an application service that is only loaded when the gradle project is refreshed to prevent it ever getting into a bad state 
==COMMIT_MSG==
Cache is loaded on first instance and on project refresh
==COMMIT_MSG==

## Possible downsides?
This has only been tested on my laptop with a fairly small gradle cache so may have performance issues on others laptops

