### PR TITLE
maintain order of repositories read from xml

### DIFF
--- a/changelog/@unreleased/pr-46.v2.yml
+++ b/changelog/@unreleased/pr-46.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: maintain order of repositories read from xml
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/46

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.intellij.openapi.project.Project;
 import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +53,7 @@ public final class RepositoryLoader {
             Repositories repositories = XML_MAPPER.readValue(mavenRepoFile, Repositories.class);
             return repositories.repositories().stream()
                     .map(RepositoryConfig::url)
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
         } catch (IOException e) {
             log.error("Failed to load repositories", e);
         }


### PR DESCRIPTION
## Before this PR
stroing the repo urls in an unordered set resulted in a random order 

## After this PR
Now we use a `LinkedHashSet` to maintain the order of the set 
==COMMIT_MSG==
maintain order of repositories read from xml
==COMMIT_MSG==

