### PR TITLE
filter for rc and snapshot in versions

### DIFF
--- a/changelog/@unreleased/pr-48.v2.yml
+++ b/changelog/@unreleased/pr-48.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: filter for rc and snapshot in versions
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/48

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Metadata.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Metadata.java
@@ -44,4 +44,10 @@ interface Metadata {
     @JacksonXmlElementWrapper(useWrapping = false)
     @JacksonXmlProperty(localName = "versioning")
     Versioning versioning();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableMetadata.Builder {}
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -17,7 +17,6 @@
 package com.palantir.gradle.versions.intellij;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
-import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
@@ -44,8 +43,8 @@ import org.slf4j.LoggerFactory;
 public class RepositoryExplorer {
     private static final Logger log = LoggerFactory.getLogger(RepositoryExplorer.class);
 
-    private static final Pattern UNSTABLE_VERSION_PATTERN =
-            Pattern.compile(".*(-rc\\d*|-SNAPSHOT|-M\\d+|-alpha|-beta)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern UNSTABLE_VERSION_PATTERN = Pattern.compile(
+            ".*(-rc(\\d+|-\\d+)?|-SNAPSHOT|-M\\d+|-alpha(\\d+|-\\d+)?|-beta(\\d+|-\\d+)?)$", Pattern.CASE_INSENSITIVE);
 
     private final Cache<CacheKey, Set<GroupPartOrPackageName>> folderCache = Caffeine.newBuilder()
             .expireAfterWrite(10, TimeUnit.MINUTES)
@@ -115,7 +114,6 @@ public class RepositoryExplorer {
     private Set<DependencyVersion> parseVersionsFromContent(String content) {
         try {
             XmlMapper xmlMapper = new XmlMapper();
-            xmlMapper.registerModule(new GuavaModule());
 
             Metadata metadata = xmlMapper.readValue(content, Metadata.class);
             return parseVersionsFromContent(metadata);

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -134,15 +134,17 @@ public class RepositoryExplorer {
             return Collections.emptySet();
         }
 
-        String metadataReleaseOrLatest = Optional.ofNullable(
+        String releaseOrLatestVersion = Optional.ofNullable(
                         metadata.versioning().release())
                 .filter(l -> !l.isEmpty())
                 .orElseGet(() -> metadata.versioning().latest());
 
-        String latestStableVersion = Optional.of(metadataReleaseOrLatest)
+        // Check if the releaseOrLatestVersion is stable, it not find first stable version, if no stable versions return
+        // the releaseOrLatestVersion
+        String latestStableVersion = Optional.of(releaseOrLatestVersion)
                 .filter(this::isStableVersion)
                 .or(() -> allVersions.stream().filter(this::isStableVersion).findFirst())
-                .orElse(metadataReleaseOrLatest);
+                .orElse(releaseOrLatestVersion);
 
         return allVersions.stream()
                 .map(version -> DependencyVersion.of(version, latestStableVersion.equals(version)))

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -45,7 +45,7 @@ public class RepositoryExplorer {
     private static final Logger log = LoggerFactory.getLogger(RepositoryExplorer.class);
 
     private static final Pattern UNSTABLE_VERSION_PATTERN = Pattern.compile(
-            ".*(-rc(\\d+|-\\d+)?|-SNAPSHOT|-M\\d+|-alpha(\\d+|-\\d+)?|-beta(\\d+|-\\d+)?)$", Pattern.CASE_INSENSITIVE);
+            ".*(-rc(-?\\d+)?|-SNAPSHOT|-M\\d+|-alpha(-?\\d+)?|-beta(-?\\d+)?)$", Pattern.CASE_INSENSITIVE);
 
     private final Cache<CacheKey, Set<GroupPartOrPackageName>> folderCache = Caffeine.newBuilder()
             .expireAfterWrite(10, TimeUnit.MINUTES)

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -127,7 +128,6 @@ public class RepositoryExplorer {
     @VisibleForTesting
     final Set<DependencyVersion> parseVersionsFromContent(Metadata metadata) {
         List<String> allVersions = new ArrayList<>(metadata.versioning().versions());
-        Collections.reverse(allVersions);
 
         if (allVersions.isEmpty()) {
             return Collections.emptySet();
@@ -142,10 +142,10 @@ public class RepositoryExplorer {
         // the releaseOrLatestVersion
         String latestStableVersion = Optional.of(releaseOrLatestVersion)
                 .filter(this::isStableVersion)
-                .or(() -> allVersions.stream().filter(this::isStableVersion).findFirst())
+                .or(() -> Lists.reverse(allVersions).stream()
+                        .filter(this::isStableVersion)
+                        .findFirst())
                 .orElse(releaseOrLatestVersion);
-
-        Collections.reverse(allVersions);
 
         return allVersions.stream()
                 .map(version -> DependencyVersion.of(version, latestStableVersion.equals(version)))

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class RepositoryLoader {
-    private static final Logger log = LoggerFactory.getLogger(RepositoryExplorer.class);
+    private static final Logger log = LoggerFactory.getLogger(RepositoryLoader.class);
 
     private static final ObjectMapper XML_MAPPER = new XmlMapper().registerModule(new GuavaModule());
     private static final String MAVEN_REPOSITORIES_FILE_NAME = ".idea/gcv-maven-repositories.xml";

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Versioning.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Versioning.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jdkOnly = true)
 @JsonDeserialize(as = ImmutableVersioning.class)
 @JsonSerialize(as = ImmutableVersioning.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -48,4 +49,10 @@ interface Versioning {
     @JacksonXmlElementWrapper(localName = "versions")
     @JacksonXmlProperty(localName = "version")
     List<String> versions();
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    class Builder extends ImmutableVersioning.Builder {}
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Versioning.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Versioning.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -46,5 +47,5 @@ interface Versioning {
     @Value.Parameter
     @JacksonXmlElementWrapper(localName = "versions")
     @JacksonXmlProperty(localName = "version")
-    String[] versions();
+    List<String> versions();
 }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryExplorerTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryExplorerTests.java
@@ -28,14 +28,14 @@ public class RepositoryExplorerTests {
     void test_gets_release_from_metadata() {
         RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
 
-        Versioning versioning = ImmutableVersioning.builder()
+        Versioning versioning = Versioning.builder()
                 .release("2.0.0")
                 .latest("1.0.0")
                 .versions(List.of("1.0.0", "2.0.0"))
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = ImmutableMetadata.builder()
+        Metadata metadata = Metadata.builder()
                 .groupId("com.example")
                 .artifactId("example-artifact")
                 .versioning(versioning)
@@ -54,14 +54,14 @@ public class RepositoryExplorerTests {
     void test_gets_latest_from_metadata_if_release_missing() {
         RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
 
-        Versioning versioning = ImmutableVersioning.builder()
+        Versioning versioning = Versioning.builder()
                 .release("")
                 .latest("2.0.0")
                 .versions(List.of("1.0.0", "2.0.0"))
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = ImmutableMetadata.builder()
+        Metadata metadata = Metadata.builder()
                 .groupId("com.example")
                 .artifactId("example-artifact")
                 .versioning(versioning)
@@ -80,15 +80,27 @@ public class RepositoryExplorerTests {
     void test_unstable_versions_are_skipped() {
         RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
 
-        Versioning versioning = ImmutableVersioning.builder()
+        Versioning versioning = Versioning.builder()
                 .release("2.1.0-SNAPSHOT")
                 .latest("2.1.0-SNAPSHOT")
                 .versions(List.of(
-                        "1.0.0", "2.0.0", "2.1.0-rc1", "2.1.0-M2", "2.1.0-alpha", "2.1.0-beta", "2.1.0-SNAPSHOT"))
+                        "1.0.0",
+                        "2.0.0",
+                        "2.1.0-rc",
+                        "2.1.0-rc1",
+                        "2.1.0-rc-2",
+                        "2.1.0-M2",
+                        "2.1.0-alpha",
+                        "2.1.0-alpha2",
+                        "2.1.0-alpha-3",
+                        "2.1.0-beta",
+                        "2.1.0-beta-2",
+                        "2.1.0-beta3",
+                        "2.1.0-SNAPSHOT"))
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = ImmutableMetadata.builder()
+        Metadata metadata = Metadata.builder()
                 .groupId("com.example")
                 .artifactId("example-artifact")
                 .versioning(versioning)
@@ -99,7 +111,33 @@ public class RepositoryExplorerTests {
         assertThat(versions).as("Check that versions set is not empty").isNotEmpty();
 
         assertThat(versions)
-                .as("Check that versions set contains the latest version marked as latest")
+                .as("Check that regex rejects all unstable versions")
                 .anyMatch(v -> v.version().equals("2.0.0") && v.isLatest());
+    }
+
+    @Test
+    void test_rc_in_name_is_matched() {
+        RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
+
+        Versioning versioning = Versioning.builder()
+                .release("2.1.0-SNAPSHOT")
+                .latest("2.1.0-SNAPSHOT")
+                .versions(List.of("1.0.0", "rc-2.0.0", "2.1.0-SNAPSHOT"))
+                .lastUpdated("unimportant")
+                .build();
+
+        Metadata metadata = Metadata.builder()
+                .groupId("com.example")
+                .artifactId("example-artifact")
+                .versioning(versioning)
+                .build();
+
+        Set<DependencyVersion> versions = repositoryExplorer.parseVersionsFromContent(metadata);
+
+        assertThat(versions).as("Check that versions set is not empty").isNotEmpty();
+
+        assertThat(versions)
+                .as("Check that rc can be used in a version name")
+                .anyMatch(v -> v.version().equals("rc-2.0.0") && v.isLatest());
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryExplorerTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryExplorerTests.java
@@ -1,0 +1,105 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions.intellij;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class RepositoryExplorerTests {
+
+    @Test
+    void test_gets_release_from_metadata() {
+        RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
+
+        Versioning versioning = ImmutableVersioning.builder()
+                .release("2.0.0")
+                .latest("1.0.0")
+                .versions(List.of("1.0.0", "2.0.0"))
+                .lastUpdated("unimportant")
+                .build();
+
+        Metadata metadata = ImmutableMetadata.builder()
+                .groupId("com.example")
+                .artifactId("example-artifact")
+                .versioning(versioning)
+                .build();
+
+        Set<DependencyVersion> versions = repositoryExplorer.parseVersionsFromContent(metadata);
+
+        assertThat(versions).as("Check that versions set is not empty").isNotEmpty();
+
+        assertThat(versions)
+                .as("Check that versions set contains the release version marked as latest")
+                .anyMatch(v -> v.version().equals("2.0.0") && v.isLatest());
+    }
+
+    @Test
+    void test_gets_latest_from_metadata_if_release_missing() {
+        RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
+
+        Versioning versioning = ImmutableVersioning.builder()
+                .release("")
+                .latest("2.0.0")
+                .versions(List.of("1.0.0", "2.0.0"))
+                .lastUpdated("unimportant")
+                .build();
+
+        Metadata metadata = ImmutableMetadata.builder()
+                .groupId("com.example")
+                .artifactId("example-artifact")
+                .versioning(versioning)
+                .build();
+
+        Set<DependencyVersion> versions = repositoryExplorer.parseVersionsFromContent(metadata);
+
+        assertThat(versions).as("Check that versions set is not empty").isNotEmpty();
+
+        assertThat(versions)
+                .as("Check that versions set contains the latest version marked as latest")
+                .anyMatch(v -> v.version().equals("2.0.0") && v.isLatest());
+    }
+
+    @Test
+    void test_unstable_versions_are_skipped() {
+        RepositoryExplorer repositoryExplorer = new RepositoryExplorer();
+
+        Versioning versioning = ImmutableVersioning.builder()
+                .release("2.1.0-SNAPSHOT")
+                .latest("2.1.0-SNAPSHOT")
+                .versions(List.of(
+                        "1.0.0", "2.0.0", "2.1.0-rc1", "2.1.0-M2", "2.1.0-alpha", "2.1.0-beta", "2.1.0-SNAPSHOT"))
+                .lastUpdated("unimportant")
+                .build();
+
+        Metadata metadata = ImmutableMetadata.builder()
+                .groupId("com.example")
+                .artifactId("example-artifact")
+                .versioning(versioning)
+                .build();
+
+        Set<DependencyVersion> versions = repositoryExplorer.parseVersionsFromContent(metadata);
+
+        assertThat(versions).as("Check that versions set is not empty").isNotEmpty();
+
+        assertThat(versions)
+                .as("Check that versions set contains the latest version marked as latest")
+                .anyMatch(v -> v.version().equals("2.0.0") && v.isLatest());
+    }
+}


### PR DESCRIPTION
## Before this PR
We would always get the latest version from the xml, however this may be an rc or snapshot version

## After this PR
Now we try and get the release version and fall back onto the latest version if we need to - if the release version contains rc / snapshot will will find the most recent version that doesnt to set as the latest version
==COMMIT_MSG==
filter for rc and snapshot in versions
==COMMIT_MSG==

## Possible downsides?
Extra compute time when getting the versions
