### PR TITLE
better logging for `ConnectException` in contents util

### DIFF
--- a/changelog/@unreleased/pr-50.v2.yml
+++ b/changelog/@unreleased/pr-50.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: better logging for `ConnectException` in contents util
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/50

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/ContentsUtil.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/ContentsUtil.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,20 +68,14 @@ public final class ContentsUtil {
                     throw new ProcessCanceledException();
                 }
 
-                BufferedReader in =
-                        new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
-                StringBuilder result = new StringBuilder();
-                String inputLine;
-
-                while ((inputLine = in.readLine()) != null) {
-                    if (indicator.isCanceled()) {
-                        throw new InterruptedException("Fetch cancelled");
-                    }
-                    result.append(inputLine);
+                if (indicator.isCanceled()) {
+                    throw new InterruptedException("Fetch cancelled");
                 }
 
-                in.close();
-                return result.toString();
+                BufferedReader in =
+                        new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+
+                return in.lines().collect(Collectors.joining("\n"));
             } catch (ConnectException e) {
                 log.error("Connection refused on page {}", pageUrl, e);
                 throw e;

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/ContentsUtil.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/ContentsUtil.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -57,29 +58,37 @@ public final class ContentsUtil {
 
     private static Callable<String> fetchContentTask(URL pageUrl, ProgressIndicator indicator) {
         return () -> {
-            HttpURLConnection connection = (HttpURLConnection) pageUrl.openConnection();
-            connection.setRequestMethod("GET");
+            HttpURLConnection connection = null;
+            try {
+                connection = (HttpURLConnection) pageUrl.openConnection();
+                connection.setRequestMethod("GET");
 
-            if (connection.getResponseCode() != 200) {
-                connection.disconnect();
-                throw new ProcessCanceledException();
-            }
-
-            BufferedReader in =
-                    new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
-            StringBuilder result = new StringBuilder();
-            String inputLine;
-
-            while ((inputLine = in.readLine()) != null) {
-                if (indicator.isCanceled()) {
-                    throw new InterruptedException("Fetch cancelled");
+                if (connection.getResponseCode() != 200) {
+                    throw new ProcessCanceledException();
                 }
-                result.append(inputLine);
-            }
 
-            in.close();
-            connection.disconnect();
-            return result.toString();
+                BufferedReader in =
+                        new BufferedReader(new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8));
+                StringBuilder result = new StringBuilder();
+                String inputLine;
+
+                while ((inputLine = in.readLine()) != null) {
+                    if (indicator.isCanceled()) {
+                        throw new InterruptedException("Fetch cancelled");
+                    }
+                    result.append(inputLine);
+                }
+
+                in.close();
+                return result.toString();
+            } catch (ConnectException e) {
+                log.error("Connection refused on page {}", pageUrl, e);
+                throw e;
+            } finally {
+                if (connection != null) {
+                    connection.disconnect();
+                }
+            }
         };
     }
 

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/ContentsUtil.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/ContentsUtil.java
@@ -64,12 +64,8 @@ public final class ContentsUtil {
                 connection = (HttpURLConnection) pageUrl.openConnection();
                 connection.setRequestMethod("GET");
 
-                if (connection.getResponseCode() != 200) {
+                if (indicator.isCanceled() || connection.getResponseCode() != 200) {
                     throw new ProcessCanceledException();
-                }
-
-                if (indicator.isCanceled()) {
-                    throw new InterruptedException("Fetch cancelled");
                 }
 
                 BufferedReader in =
@@ -77,8 +73,8 @@ public final class ContentsUtil {
 
                 return in.lines().collect(Collectors.joining("\n"));
             } catch (ConnectException e) {
-                log.error("Connection refused on page {}", pageUrl, e);
-                throw e;
+                log.debug("Connection refused on page {}", pageUrl, e);
+                return null;
             } finally {
                 if (connection != null) {
                     connection.disconnect();

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class RepositoryLoader {
-    private static final Logger log = LoggerFactory.getLogger(RepositoryExplorer.class);
+    private static final Logger log = LoggerFactory.getLogger(RepositoryLoader.class);
 
     private static final ObjectMapper XML_MAPPER = new XmlMapper().registerModule(new GuavaModule());
     private static final String MAVEN_REPOSITORIES_FILE_NAME = ".idea/gcv-maven-repositories.xml";


### PR DESCRIPTION
## Before this PR
Sometimes we where getting the below error and there was no way of determining which repo url was causing it

```
java.net.ConnectException: Connection refused
	at java.base/sun.nio.ch.Net.connect0(Native Method)
	at java.base/sun.nio.ch.Net.connect(Net.java:589)
	at java.base/sun.nio.ch.Net.connect(Net.java:578)
	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:583)
	at java.base/java.net.Socket.connect(Socket.java:751)
	at java.base/java.net.Socket.connect(Socket.java:686)
	at java.base/sun.net.NetworkClient.doConnect(NetworkClient.java:183)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:531)
	at java.base/sun.net.www.http.HttpClient.openServer(HttpClient.java:636)
	at java.base/sun.net.www.http.HttpClient.<init>(HttpClient.java:280)
	at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:386)
	at java.base/sun.net.www.http.HttpClient.New(HttpClient.java:408)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(HttpURLConnection.java:1304)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1237)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1123)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:1052)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1675)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1599)
	at java.base/java.net.HttpURLConnection.getResponseCode(HttpURLConnection.java:531)
	at com.palantir.gradle.versions.intellij.ContentsUtil.lambda$fetchContentTask$0(ContentsUtil.java:63)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport$executeOnPooledThread$2.call(AnyThreadWriteThreadingSupport.kt:162)
	at com.intellij.util.concurrency.ContextCallable.call(ContextCallable.java:32)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:27)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:735)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:732)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:732)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

## After this PR
Now we specifically look for and log this error with more detail to make debugging easier
==COMMIT_MSG==
better logging for `ConnectException` in contents util
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

