### PR TITLE
Suggest the * wild card match for package names

### DIFF
--- a/changelog/@unreleased/pr-51.v2.yml
+++ b/changelog/@unreleased/pr-51.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Suggest the * wild card match for package names
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/51

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/FolderCompletionContributor.java
@@ -69,7 +69,10 @@ public class FolderCompletionContributor extends CompletionContributor {
                 Project project = parameters.getOriginalFile().getProject();
 
                 GradleCacheExplorer.getInstance()
-                        .getCompletions(RepositoryLoader.loadRepositories(project), group)
+                        .getCompletions(
+                                RepositoryLoader.loadRepositories(project),
+                                group,
+                                elementType == VersionPropsTypes.NAME_KEY)
                         .stream()
                         .map(suggestion -> LookupElementBuilder.create(GroupPartOrPackageName.of(suggestion)))
                         .forEach(resultSet::addElement);

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
@@ -16,6 +16,7 @@
 
 package com.palantir.gradle.versions.intellij;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.intellij.openapi.application.ApplicationManager;
 import java.io.BufferedInputStream;
@@ -42,6 +43,11 @@ public class GradleCacheExplorer {
 
     GradleCacheExplorer() {
         loadCache();
+    }
+
+    @VisibleForTesting
+    GradleCacheExplorer(Set<String> newCache) {
+        cache.set(newCache);
     }
 
     public final void loadCache() {
@@ -185,10 +191,5 @@ public class GradleCacheExplorer {
 
     static GradleCacheExplorer getInstance() {
         return ApplicationManager.getApplication().getService(GradleCacheExplorer.class);
-    }
-
-    // This should only ever be used by tests
-    final void setCacheForTesting(Set<String> newCache) {
-        cache.set(newCache);
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
@@ -64,9 +64,8 @@ public class GradleCacheExplorer {
                 .flatMap(Optional::stream)
                 .collect(Collectors.toSet());
 
-        Set<String> resultsWithStarsIncluded = results.stream()
-                .flatMap(result -> includeStarsIfMultipleArtifacts(result, results))
-                .collect(Collectors.toSet());
+        Set<String> resultsWithStarsIncluded =
+                results.stream().flatMap(GradleCacheExplorer::includeStars).collect(Collectors.toSet());
 
         if (parsedInput.isEmpty()) {
             return resultsWithStarsIncluded;
@@ -89,15 +88,11 @@ public class GradleCacheExplorer {
         return filteredResults;
     }
 
-    static Stream<String> includeStarsIfMultipleArtifacts(String result, Set<String> results) {
+    static Stream<String> includeStars(String result) {
         int colonIndex = result.indexOf(':');
         if (colonIndex != -1) {
             String prefix = result.substring(0, colonIndex);
-            long count =
-                    results.stream().filter(r -> r.startsWith(prefix + ":")).count();
-            if (count > 1) {
-                return Stream.of(result, prefix + ":*");
-            }
+            return Stream.of(result, prefix + ":*");
         }
         return Stream.of(result);
     }

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/GradleCacheExplorer.java
@@ -65,19 +65,7 @@ public class GradleCacheExplorer {
                 .collect(Collectors.toSet());
 
         Set<String> resultsWithStarsIncluded = results.stream()
-                .flatMap(result -> {
-                    int colonIndex = result.indexOf(':');
-                    if (colonIndex != -1) {
-                        String prefix = result.substring(0, colonIndex);
-                        long count = results.stream()
-                                .filter(r -> r.startsWith(prefix + ":"))
-                                .count();
-                        if (count > 1) {
-                            return Stream.of(result, prefix + ":*");
-                        }
-                    }
-                    return Stream.of(result);
-                })
+                .flatMap(result -> includeStarsIfMultipleArtifacts(result, results))
                 .collect(Collectors.toSet());
 
         if (parsedInput.isEmpty()) {
@@ -99,6 +87,19 @@ public class GradleCacheExplorer {
         log.debug("Completion matching time: {} ms", stopWatch.elapsed().toMillis());
 
         return filteredResults;
+    }
+
+    static Stream<String> includeStarsIfMultipleArtifacts(String result, Set<String> results) {
+        int colonIndex = result.indexOf(':');
+        if (colonIndex != -1) {
+            String prefix = result.substring(0, colonIndex);
+            long count =
+                    results.stream().filter(r -> r.startsWith(prefix + ":")).count();
+            if (count > 1) {
+                return Stream.of(result, prefix + ":*");
+            }
+        }
+        return Stream.of(result);
     }
 
     private Set<String> extractStrings() {

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
@@ -103,4 +103,92 @@ class GradleCacheExplorerTest {
                 .as("Empty passed in so empty returned")
                 .isEmpty();
     }
+
+    @Test
+    void test_get_completion_no_match() {
+        Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
+        Set<String> cache = Set.of(
+                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
+                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
+                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+
+        explorer.setCacheForTesting(cache);
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("org.expected"), false))
+                .as("No group match")
+                .isEmpty();
+    }
+
+    @Test
+    void test_get_completion_match_all() {
+        Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
+        Set<String> cache = Set.of(
+                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
+                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
+                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+
+        explorer.setCacheForTesting(cache);
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
+                .as("Matches all")
+                .containsOnly(
+                        "com.exampleDifferent:artifactOne",
+                        "com.exampleTwo:*",
+                        "org.exampleOrg:artifactOrg",
+                        "com.exampleOne:artifactOne",
+                        "com.exampleTwo:artifactTwo",
+                        "com.exampleOne:*",
+                        "com.exampleOne:artifactTwo",
+                        "com.exampleTwo:artifactOne");
+    }
+
+    @Test
+    void test_get_completion_match_some() {
+        Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
+        Set<String> cache = Set.of(
+                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
+                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
+                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+
+        explorer.setCacheForTesting(cache);
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("com"), false))
+                .as("Matches all")
+                .containsOnly(
+                        "exampleOne:*",
+                        "exampleOne:artifactOne",
+                        "exampleOne:artifactTwo",
+                        "exampleDifferent:artifactOne",
+                        "exampleTwo:*",
+                        "exampleTwo:artifactOne",
+                        "exampleTwo:artifactTwo");
+    }
+
+    @Test
+    void test_get_completion_match_is_package_name() {
+        Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
+        Set<String> cache = Set.of(
+                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/com/exampleOne/anotherGroup/artifactOne/1.0/artifact-1.0.jar",
+                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
+                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
+                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
+                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
+                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+
+        explorer.setCacheForTesting(cache);
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("com.exampleOne"), true))
+                .as("Matches all")
+                .containsOnly("*", "artifactOne", "artifactTwo");
+    }
 }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
@@ -182,8 +182,44 @@ class GradleCacheExplorerTest {
         explorer = new GradleCacheExplorer(cache);
 
         assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("same.group"), false))
-                .as(
-                        "When a group is passed only packages that match are suggested and the group is removed from the start")
+                .as("When a group is passed only packages that match are suggested")
                 .containsOnly("*", "nameOne", "nameTwo");
+    }
+
+    @Test
+    public void test_if_multiple_matching_groups_adds_star() {
+        Set<String> results = Set.of("group1:artifact1", "group1:artifact2", "group2:artifact1");
+        String result = "group1:artifact1";
+        Set<String> expected = Set.of("group1:artifact1", "group1:*");
+
+        Set<String> actual = GradleCacheExplorer.includeStarsIfMultipleArtifacts(result, results)
+                .collect(Collectors.toSet());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void test_single_artifact_has_group_no_star_added() {
+        Set<String> results = Set.of("group1:artifact1", "group1:artifact2", "group2:artifact1");
+        String result = "group2:artifact1";
+        Set<String> expected = Set.of("group2:artifact1");
+
+        Set<String> actual = GradleCacheExplorer.includeStarsIfMultipleArtifacts(result, results)
+                .collect(Collectors.toSet());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void test_returns_input_if_no_colon() {
+        Set<String> results = Set.of("group1:artifact1", "group1:artifact2", "group2:artifact1");
+
+        String result = "group3artifact1";
+        Set<String> expected = Set.of("group3artifact1");
+
+        Set<String> actual = GradleCacheExplorer.includeStarsIfMultipleArtifacts(result, results)
+                .collect(Collectors.toSet());
+
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -35,13 +34,9 @@ class GradleCacheExplorerTest {
 
     private GradleCacheExplorer explorer;
 
-    @BeforeEach
-    void beforeEach() {
-        explorer = new GradleCacheExplorer();
-    }
-
     @Test
     void test_gets_valid_urls_only() {
+        explorer = new GradleCacheExplorer();
         assertThat(explorer.isValidResourceUrl(
                         "https://repo.maven.apache.org/maven2/com/example/artifact/1.0/artifact-1.0.pom"))
                 .as("because the URL is from a known valid repository and ends with .pom")
@@ -63,6 +58,7 @@ class GradleCacheExplorerTest {
 
     @Test
     void test_gets_all_strings_from_bin(@TempDir File tempDir) throws IOException {
+        explorer = new GradleCacheExplorer();
         File tempFile = new File(tempDir, "test.bin");
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(tempFile, StandardCharsets.UTF_8))) {
             writer.write("hello.jar\nworld.pom\nanother.jar\b\f");
@@ -78,6 +74,7 @@ class GradleCacheExplorerTest {
 
     @Test
     void test_extract_group_artifact_from_url_correctly() {
+        explorer = new GradleCacheExplorer();
         Set<String> projectUrls = Set.of("https://repo.maven.apache.org/maven2/", "https://jcenter.bintray.com/");
 
         assertThat(explorer.extractGroupAndArtifactFromUrl(
@@ -108,15 +105,12 @@ class GradleCacheExplorerTest {
     void test_get_completion_no_match() {
         Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
         Set<String> cache = Set.of(
-                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
-                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
-                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+                "https://example.one/exampleOne/nameOne/version/artifact.pom",
+                "https://example.two/exampleTwo/nameTwo/version/artifact.pom",
+                "https://not.included.url/exampleThree/exampleThree/version/artifact.pom");
 
-        explorer.setCacheForTesting(cache);
+        explorer = new GradleCacheExplorer(cache);
+
         assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("org.expected"), false))
                 .as("No group match")
                 .isEmpty();
@@ -126,69 +120,70 @@ class GradleCacheExplorerTest {
     void test_get_completion_match_all() {
         Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
         Set<String> cache = Set.of(
-                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
-                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
-                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+                "https://example.one/exampleOne/nameOne/version/artifact.pom",
+                "https://example.two/exampleTwo/nameTwo/version/artifact.pom");
 
-        explorer.setCacheForTesting(cache);
+        explorer = new GradleCacheExplorer(cache);
+
         assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
                 .as("Matches all")
-                .containsOnly(
-                        "com.exampleDifferent:artifactOne",
-                        "com.exampleTwo:*",
-                        "org.exampleOrg:artifactOrg",
-                        "com.exampleOne:artifactOne",
-                        "com.exampleTwo:artifactTwo",
-                        "com.exampleOne:*",
-                        "com.exampleOne:artifactTwo",
-                        "com.exampleTwo:artifactOne");
+                .containsOnly("exampleOne:nameOne", "exampleTwo:nameTwo");
     }
 
     @Test
-    void test_get_completion_match_some() {
-        Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
+    void test_ignore_if_not_in_repo_list() {
+        Set<String> repoUrls = Set.of("https://example.one/");
         Set<String> cache = Set.of(
-                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
-                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
-                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+                "https://example.one/exampleOne/nameOne/version/artifact.pom",
+                "https://example.two/exampleTwo/nameTwo/version/artifact.pom");
 
-        explorer.setCacheForTesting(cache);
-        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("com"), false))
+        explorer = new GradleCacheExplorer(cache);
+
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
                 .as("Matches all")
-                .containsOnly(
-                        "exampleOne:*",
-                        "exampleOne:artifactOne",
-                        "exampleOne:artifactTwo",
-                        "exampleDifferent:artifactOne",
-                        "exampleTwo:*",
-                        "exampleTwo:artifactOne",
-                        "exampleTwo:artifactTwo");
+                .containsOnly("exampleOne:nameOne");
     }
 
     @Test
-    void test_get_completion_match_is_package_name() {
+    void test_long_urls_correctly_parsed() {
+        Set<String> repoUrls = Set.of("https://example.one/");
+        Set<String> cache = Set.of("https://example.one/this/is/a/very/long/url/version/artifact.pom");
+
+        explorer = new GradleCacheExplorer(cache);
+
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
+                .as("Long url broken into group and artifact")
+                .containsOnly("this.is.a.very.long:url");
+    }
+
+    @Test
+    void test_two_packages_with_same_group_suggests_wildcard() {
+        Set<String> repoUrls = Set.of("https://example.one/");
+        Set<String> cache = Set.of(
+                "https://example.one/same/group/nameOne/version/artifact.pom",
+                "https://example.one/same/group/nameTwo/version/artifact.pom");
+
+        explorer = new GradleCacheExplorer(cache);
+
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
+                .as("If more than one package with same group a wildcard is suggested")
+                .containsOnly("same.group:*", "same.group:nameOne", "same.group:nameTwo");
+    }
+
+    @Test
+    void test_matches_based_on_group_and_wildcard_suggested_across_urls() {
         Set<String> repoUrls = Set.of("https://example.one/", "https://example.two/");
         Set<String> cache = Set.of(
-                "https://example.one/com/exampleOne/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.one/com/exampleOne/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/com/exampleOne/anotherGroup/artifactOne/1.0/artifact-1.0.jar",
-                "https://example.one/com/exampleDifferent/artifactOne/1.0/artifact-1.0.jar",
-                "https://example.two/com/exampleTwo/artifactOne/1.0/artifact-1.0.pom",
-                "https://example.two/com/exampleTwo/artifactTwo/1.0/artifact-1.0.jar",
-                "https://example.one/org/exampleOrg/artifactOrg/1.0/artifact-1.0.pom",
-                "https://example.three/com/exampleThree/artifactOne/1.0/artifact-1.0.pom");
+                "https://example.one/same/group/nameOne/version/artifact.pom",
+                "https://example.one/different/group/differentNameOne/version/artifact.pom",
+                "https://example.two/same/group/nameTwo/version/artifact.pom",
+                "https://example.two/different/group/differentNameTwo/version/artifact.pom");
 
-        explorer.setCacheForTesting(cache);
-        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("com.exampleOne"), true))
-                .as("Matches all")
-                .containsOnly("*", "artifactOne", "artifactTwo");
+        explorer = new GradleCacheExplorer(cache);
+
+        assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString("same.group"), false))
+                .as(
+                        "When a group is passed only packages that match are suggested and the group is removed from the start")
+                .containsOnly("*", "nameOne", "nameTwo");
     }
 }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/GradleCacheExplorerTest.java
@@ -127,7 +127,7 @@ class GradleCacheExplorerTest {
 
         assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
                 .as("Matches all")
-                .containsOnly("exampleOne:nameOne", "exampleTwo:nameTwo");
+                .containsOnly("exampleOne:nameOne", "exampleOne:*", "exampleTwo:nameTwo", "exampleTwo:*");
     }
 
     @Test
@@ -141,7 +141,7 @@ class GradleCacheExplorerTest {
 
         assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
                 .as("Matches all")
-                .containsOnly("exampleOne:nameOne");
+                .containsOnly("exampleOne:nameOne", "exampleOne:*");
     }
 
     @Test
@@ -153,11 +153,11 @@ class GradleCacheExplorerTest {
 
         assertThat(explorer.getCompletions(repoUrls, DependencyGroup.fromString(""), false))
                 .as("Long url broken into group and artifact")
-                .containsOnly("this.is.a.very.long:url");
+                .containsOnly("this.is.a.very.long:url", "this.is.a.very.long:*");
     }
 
     @Test
-    void test_two_packages_with_same_group_suggests_wildcard() {
+    void test_two_packages_with_same_group_suggests_one_wildcard() {
         Set<String> repoUrls = Set.of("https://example.one/");
         Set<String> cache = Set.of(
                 "https://example.one/same/group/nameOne/version/artifact.pom",
@@ -187,38 +187,21 @@ class GradleCacheExplorerTest {
     }
 
     @Test
-    public void test_if_multiple_matching_groups_adds_star() {
-        Set<String> results = Set.of("group1:artifact1", "group1:artifact2", "group2:artifact1");
+    public void test_if_adds_star() {
         String result = "group1:artifact1";
         Set<String> expected = Set.of("group1:artifact1", "group1:*");
 
-        Set<String> actual = GradleCacheExplorer.includeStarsIfMultipleArtifacts(result, results)
-                .collect(Collectors.toSet());
-
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    public void test_single_artifact_has_group_no_star_added() {
-        Set<String> results = Set.of("group1:artifact1", "group1:artifact2", "group2:artifact1");
-        String result = "group2:artifact1";
-        Set<String> expected = Set.of("group2:artifact1");
-
-        Set<String> actual = GradleCacheExplorer.includeStarsIfMultipleArtifacts(result, results)
-                .collect(Collectors.toSet());
+        Set<String> actual = GradleCacheExplorer.includeStars(result).collect(Collectors.toSet());
 
         assertThat(actual).isEqualTo(expected);
     }
 
     @Test
     public void test_returns_input_if_no_colon() {
-        Set<String> results = Set.of("group1:artifact1", "group1:artifact2", "group2:artifact1");
-
         String result = "group3artifact1";
         Set<String> expected = Set.of("group3artifact1");
 
-        Set<String> actual = GradleCacheExplorer.includeStarsIfMultipleArtifacts(result, results)
-                .collect(Collectors.toSet());
+        Set<String> actual = GradleCacheExplorer.includeStars(result).collect(Collectors.toSet());
 
         assertThat(actual).isEqualTo(expected);
     }


### PR DESCRIPTION
## Before this PR
The plugin never suggested using wild cards this is bad as it discourages the use of it

## After this PR
We now always will suggest the use of a * wildcard match for package name

We have also fixed a bug where groups contain a deeper group and packages e.g. you have typed `com.example.group:` and you get suggested `packageName1` and also `deeperGroup:otherPackageName`
 
==COMMIT_MSG==
Suggest the * wild card match for package names
==COMMIT_MSG==

## Possible downsides?
This means we now always suggest a * without checking if a * is possible for a particular project - we feel this is better than not suggesting a * at all though

