### PR TITLE
Maintain version order from xml

### DIFF
--- a/changelog/@unreleased/pr-52.v2.yml
+++ b/changelog/@unreleased/pr-52.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Maintain version order from xml
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/52

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -21,10 +21,9 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -66,14 +65,14 @@ public class RepositoryExplorer {
         return fetchFoldersFromContent(content.get());
     }
 
-    public final List<DependencyVersion> getVersions(
+    public final Set<DependencyVersion> getVersions(
             DependencyGroup group, DependencyName dependencyPackage, String url) {
         String urlString = url + group.asUrlString() + dependencyPackage.name() + "/maven-metadata.xml";
         Optional<String> content = fetchContent(urlString);
 
         if (content.isEmpty()) {
             log.debug("Empty metadata content received");
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
 
         return parseVersionsFromContent(content.get());
@@ -104,8 +103,8 @@ public class RepositoryExplorer {
         return folders;
     }
 
-    private List<DependencyVersion> parseVersionsFromContent(String content) {
-        List<DependencyVersion> versions = new ArrayList<>();
+    private Set<DependencyVersion> parseVersionsFromContent(String content) {
+        Set<DependencyVersion> versions = new LinkedHashSet<>();
         try {
             XmlMapper xmlMapper = new XmlMapper();
 

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryExplorer.java
@@ -21,8 +21,10 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -64,14 +66,14 @@ public class RepositoryExplorer {
         return fetchFoldersFromContent(content.get());
     }
 
-    public final Set<DependencyVersion> getVersions(
+    public final List<DependencyVersion> getVersions(
             DependencyGroup group, DependencyName dependencyPackage, String url) {
         String urlString = url + group.asUrlString() + dependencyPackage.name() + "/maven-metadata.xml";
         Optional<String> content = fetchContent(urlString);
 
         if (content.isEmpty()) {
             log.debug("Empty metadata content received");
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
 
         return parseVersionsFromContent(content.get());
@@ -102,8 +104,8 @@ public class RepositoryExplorer {
         return folders;
     }
 
-    private Set<DependencyVersion> parseVersionsFromContent(String content) {
-        Set<DependencyVersion> versions = new HashSet<>();
+    private List<DependencyVersion> parseVersionsFromContent(String content) {
+        List<DependencyVersion> versions = new ArrayList<>();
         try {
             XmlMapper xmlMapper = new XmlMapper();
 

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsCodeInsightTest.java
@@ -40,11 +40,15 @@ public class VersionPropsCodeInsightTest extends LightJavaCodeInsightFixtureTest
     public void test_version_completion() {
         JavaCodeInsightTestFixture fixture = getFixture();
         // The file name is required for context but does not need to exist on the filesystem
-        fixture.configureByText("versions.props", "com.palantir.baseline:baseline-error-prone = <caret>");
+        fixture.configureByText("versions.props", "com.palantir.goethe:goethe = <caret>");
         fixture.complete(CompletionType.BASIC);
         List<String> lookupElementStrings = fixture.getLookupElementStrings();
         assertThat(lookupElementStrings).isNotNull();
-        UsefulTestCase.assertContainsElements(lookupElementStrings, "0.66.0", "2.40.2");
+        assertThat(lookupElementStrings)
+                .as("Lookup elements should be returned with this order")
+                .containsSubsequence(
+                        "0.13.0", "0.12.0", "0.11.0", "0.10.0", "0.9.0", "0.8.0", "0.7.0", "0.6.0", "0.5.0", "0.4.0",
+                        "0.3.0", "0.2.0", "0.1.0");
     }
 
     @Test


### PR DESCRIPTION
## Before this PR
The order that versions appeared in as part of a suggestion would be determined by the `sort` order of the strings of the versions

## After this PR
We now use the `PrioritizedLookupElement` to force the order to be in that of the xml e.g. descending order
==COMMIT_MSG==
Maintain version order from xml
==COMMIT_MSG==

## Possible downsides?
If versions are added from a different contributor they will not automatically gain this ordering as it is added at the contributor level
