### PR TITLE
ignore localhost and file system repositories from gcv-maven-repositories.xml

### DIFF
--- a/changelog/@unreleased/pr-56.v2.yml
+++ b/changelog/@unreleased/pr-56.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: ignore localhost and file system repositories from gcv-maven-repositories.xml
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/56

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -53,6 +53,9 @@ public final class RepositoryLoader {
             Repositories repositories = XML_MAPPER.readValue(mavenRepoFile, Repositories.class);
             return repositories.repositories().stream()
                     .map(RepositoryConfig::url)
+                    // This is a temporary workaround to ignore localhost and file system from maven local - long term
+                    // we should fix localhost on the GCV side, and we should be able to explore the maven local repo
+                    .filter(url -> !url.contains("localhost") && !url.startsWith("file:"))
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         } catch (IOException e) {
             log.error("Failed to load repositories", e);


### PR DESCRIPTION
## Before this PR
We where trying to connect to the file system and to localhost repos which was causing exceptions

## After this PR
We now filter out localhost and file system
==COMMIT_MSG==
ignore localhost and file system repositories from gcv-maven-repositories.xml
==COMMIT_MSG==

## Possible downsides?
Long term we will want to use the file system for mavenLocal and its possible someone may want to use a local host maven repo - ideally we would fix the localhost issue on the GCV side

