### PR TITLE
Order repositories based on url contents

### DIFF
--- a/changelog/@unreleased/pr-71.v2.yml
+++ b/changelog/@unreleased/pr-71.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Order repositories that are read
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/71

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -67,12 +67,12 @@ public final class RepositoryLoader {
         return Set.of(DEFAULT);
     }
 
-    private static class RepositoryComparator implements Comparator<String> {
+    private static final class RepositoryComparator implements Comparator<String> {
         private static final Map<String, Integer> KEYWORD_SCORES = Map.of(
-                "release", 10,
+                "release", 15,
                 "jar", 10,
                 "dist", -5,
-                "internal", -5);
+                "internal", -10);
 
         @Override
         public int compare(String repo1, String repo2) {

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -27,8 +27,10 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.intellij.openapi.project.Project;
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.immutables.value.Value;
@@ -56,12 +58,33 @@ public final class RepositoryLoader {
                     // This is a temporary workaround to ignore localhost and file system from maven local - long term
                     // we should fix localhost on the GCV side, and we should be able to explore the maven local repo
                     .filter(url -> !url.contains("localhost") && !url.startsWith("file:"))
+                    .sorted(new RepositoryComparator())
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         } catch (IOException e) {
             log.error("Failed to load repositories", e);
         }
 
         return Set.of(DEFAULT);
+    }
+
+    private static class RepositoryComparator implements Comparator<String> {
+        private static final Map<String, Integer> KEYWORD_SCORES = Map.of(
+                "release", 10,
+                "jar", 10,
+                "dist", -5,
+                "internal", -5);
+
+        @Override
+        public int compare(String repo1, String repo2) {
+            return Integer.compare(getScore(repo2), getScore(repo1));
+        }
+
+        private int getScore(String repo) {
+            return KEYWORD_SCORES.entrySet().stream()
+                    .filter(entry -> repo.contains(entry.getKey()))
+                    .mapToInt(Map.Entry::getValue)
+                    .sum();
+        }
     }
 
     @Value.Immutable

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/RepositoryLoader.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -76,7 +77,7 @@ public final class RepositoryLoader {
 
         @Override
         public int compare(String repo1, String repo2) {
-            return Integer.compare(getScore(repo2), getScore(repo1));
+            return Integer.compare(getScore(repo2.toLowerCase(Locale.ROOT)), getScore(repo1.toLowerCase(Locale.ROOT)));
         }
 
         private int getScore(String repo) {

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
@@ -1,0 +1,110 @@
+/*
+ * (c) Copyright 2024 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.versions.intellij;
+
+import static org.gradle.internal.impldep.org.testng.Assert.assertEquals;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 {
+
+    private static final String MAVEN_REPOSITORIES_FILE_NAME = ".idea/gcv-maven-repositories.xml";
+    private static final String DEFAULT = "https://repo.maven.apache.org/maven2/";
+
+    @Override
+    protected final String getRelativePath() {
+        return "";
+    }
+
+    @Override
+    protected final String getTestDataPath() {
+        return "";
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testLoadRepositories_fileDoesNotExist() {
+        Project project = getFixture().getProject();
+
+        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+        assertEquals(Set.of(DEFAULT), repositories, "Should return default repository when file does not exist");
+    }
+
+    @Test
+    void testLoadRepositories_fileExists() throws IOException {
+        Project project = getFixture().getProject();
+
+        createMavenRepositoriesFile(
+                tempDir.resolve(MAVEN_REPOSITORIES_FILE_NAME),
+                """
+                    <repositories>
+                      <repository url="https://repo1.maven.org/maven2/"/>
+                      <repository url="https://repo2.maven.org/maven2/"/>
+                    </repositories>
+                    """);
+
+        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+        System.out.println(repositories);
+        assertEquals(
+                Set.of("https://repo1.maven.org/maven2/", "https://repo2.maven.org/maven2/"),
+                repositories,
+                "Should load repositories from file");
+    }
+    //
+    //    @Test
+    //    void testLoadRepositories_ignoreLocalhostAndFile() throws IOException {
+    //        createMavenRepositoriesFile(
+    //                tempDir.resolve(MAVEN_REPOSITORIES_FILE_NAME),
+    //                """
+    //                <repositories>
+    //                  <repository url="https://repo1.maven.org/maven2/"/>
+    //                  <repository url="http://localhost:8081/nexus/content/repositories/releases/"/>
+    //                  <repository url="file:///Users/user/.m2/repository/"/>
+    //                </repositories>
+    //                """);
+    //
+    //        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+    //        assertEquals(
+    //                Set.of("https://repo1.maven.org/maven2/"),
+    //                repositories,
+    //                "Should ignore localhost and file repositories");
+    //    }
+    //
+    //    @Test
+    //    void testLoadRepositories_handlesIOException() throws IOException {
+    //        // Simulate IOException by creating a directory instead of a file
+    //        Files.createDirectory(tempDir.resolve(MAVEN_REPOSITORIES_FILE_NAME));
+    //
+    //        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+    //        assertEquals(Set.of(DEFAULT_REPO), repositories, "Should return default repository when IOException
+    // occurs");
+    //    }
+    //
+    private void createMavenRepositoriesFile(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content);
+    }
+}

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
@@ -100,10 +100,10 @@ public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 
                     <repositories>
                       <repository url="dist"/>
                       <repository url="internal"/>
-                      <repository url="release-dist"/>
+                      <repository url="RELEASE-dist"/>
                       <repository url="internal-dist"/>
                       <repository url="internal-jar"/>
-                      <repository url="release-jar"/>
+                      <repository url="release-JAR"/>
                       <repository url="release"/>
                       <repository url="random"/>
                       <repository url="jar"/>

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
@@ -16,7 +16,7 @@
 
 package com.palantir.gradle.versions.intellij;
 
-import static org.gradle.internal.impldep.org.testng.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5;
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 {
 
@@ -42,23 +41,22 @@ public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 
         return "";
     }
 
-    @TempDir
-    Path tempDir;
-
     @Test
-    void testLoadRepositories_fileDoesNotExist() {
+    void file_does_not_exist_return_default() {
         Project project = getFixture().getProject();
 
         Set<String> repositories = RepositoryLoader.loadRepositories(project);
-        assertEquals(Set.of(DEFAULT), repositories, "Should return default repository when file does not exist");
+        assertThat(repositories)
+                .as("Should return default repository when file does not exist")
+                .containsExactly(DEFAULT);
     }
 
     @Test
-    void testLoadRepositories_fileExists() throws IOException {
+    void loads_repos_for_file() throws IOException {
         Project project = getFixture().getProject();
 
         createMavenRepositoriesFile(
-                tempDir.resolve(MAVEN_REPOSITORIES_FILE_NAME),
+                project,
                 """
                     <repositories>
                       <repository url="https://repo1.maven.org/maven2/"/>
@@ -67,43 +65,68 @@ public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 
                     """);
 
         Set<String> repositories = RepositoryLoader.loadRepositories(project);
-        System.out.println(repositories);
-        assertEquals(
-                Set.of("https://repo1.maven.org/maven2/", "https://repo2.maven.org/maven2/"),
-                repositories,
-                "Should load repositories from file");
+        assertThat(repositories)
+                .as("Should load repositories from file")
+                .containsExactlyInAnyOrder("https://repo1.maven.org/maven2/", "https://repo2.maven.org/maven2/");
     }
-    //
-    //    @Test
-    //    void testLoadRepositories_ignoreLocalhostAndFile() throws IOException {
-    //        createMavenRepositoriesFile(
-    //                tempDir.resolve(MAVEN_REPOSITORIES_FILE_NAME),
-    //                """
-    //                <repositories>
-    //                  <repository url="https://repo1.maven.org/maven2/"/>
-    //                  <repository url="http://localhost:8081/nexus/content/repositories/releases/"/>
-    //                  <repository url="file:///Users/user/.m2/repository/"/>
-    //                </repositories>
-    //                """);
-    //
-    //        Set<String> repositories = RepositoryLoader.loadRepositories(project);
-    //        assertEquals(
-    //                Set.of("https://repo1.maven.org/maven2/"),
-    //                repositories,
-    //                "Should ignore localhost and file repositories");
-    //    }
-    //
-    //    @Test
-    //    void testLoadRepositories_handlesIOException() throws IOException {
-    //        // Simulate IOException by creating a directory instead of a file
-    //        Files.createDirectory(tempDir.resolve(MAVEN_REPOSITORIES_FILE_NAME));
-    //
-    //        Set<String> repositories = RepositoryLoader.loadRepositories(project);
-    //        assertEquals(Set.of(DEFAULT_REPO), repositories, "Should return default repository when IOException
-    // occurs");
-    //    }
-    //
-    private void createMavenRepositoriesFile(Path path, String content) throws IOException {
+
+    @Test
+    void local_host_and_file_paths_ignored() throws IOException {
+        Project project = getFixture().getProject();
+
+        createMavenRepositoriesFile(
+                project,
+                """
+                    <repositories>
+                      <repository url="https://repo1.maven.org/maven2/"/>
+                      <repository url="http://localhost:8081/nexus/content/repositories/releases/"/>
+                      <repository url="file:///Users/user/.m2/repository/"/>
+                    </repositories>
+                    """);
+
+        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+        assertThat(repositories)
+                .as("Should ignore localhost and file repositories")
+                .containsExactly("https://repo1.maven.org/maven2/");
+    }
+
+    @Test
+    void check_order_is_correct() throws IOException {
+        Project project = getFixture().getProject();
+
+        createMavenRepositoriesFile(
+                project,
+                """
+                    <repositories>
+                      <repository url="dist"/>
+                      <repository url="internal"/>
+                      <repository url="release-dist"/>
+                      <repository url="internal-dist"/>
+                      <repository url="internal-jar"/>
+                      <repository url="release-jar"/>
+                      <repository url="release"/>
+                      <repository url="random"/>
+                      <repository url="jar"/>
+                    </repositories>
+                    """);
+
+        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+        assertThat(repositories)
+                .as("Should maintain the correct order of repositories")
+                .containsExactly(
+                        "release-jar",
+                        "release",
+                        "release-dist",
+                        "jar",
+                        "internal-jar",
+                        "random",
+                        "dist",
+                        "internal",
+                        "internal-dist");
+    }
+
+    private void createMavenRepositoriesFile(Project project, String content) throws IOException {
+        Path path = Path.of(project.getBasePath(), MAVEN_REPOSITORIES_FILE_NAME);
         Files.createDirectories(path.getParent());
         Files.writeString(path, content);
     }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
@@ -91,7 +91,7 @@ public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 
     }
 
     @Test
-    void check_order_is_correct() throws IOException {
+    void check_order_is_corrected() throws IOException {
         Project project = getFixture().getProject();
 
         createMavenRepositoriesFile(
@@ -123,6 +123,30 @@ public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 
                         "dist",
                         "internal",
                         "internal-dist");
+    }
+
+    @Test
+    void repos_not_sorted_maintain_entry_order() throws IOException {
+        Project project = getFixture().getProject();
+
+        createMavenRepositoriesFile(
+                project,
+                """
+                    <repositories>
+                      <repository url="test1/internal"/>
+                      <repository url="test1/release"/>
+                      <repository url="random1"/>
+                      <repository url="test2/internal"/>
+                      <repository url="random2"/>
+                      <repository url="test2/release"/>
+                    </repositories>
+                    """);
+
+        Set<String> repositories = RepositoryLoader.loadRepositories(project);
+        assertThat(repositories)
+                .as("Should maintain the correct order of repositories")
+                .containsExactly(
+                        "test1/release", "test2/release", "random1", "random2", "test1/internal", "test2/internal");
     }
 
     private void createMavenRepositoriesFile(Project project, String content) throws IOException {

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryLoaderTests.java
@@ -114,9 +114,9 @@ public class RepositoryLoaderTests extends LightJavaCodeInsightFixtureTestCase5 
         assertThat(repositories)
                 .as("Should maintain the correct order of repositories")
                 .containsExactly(
-                        "release-jar",
+                        "release-JAR",
                         "release",
-                        "release-dist",
+                        "RELEASE-dist",
                         "jar",
                         "internal-jar",
                         "random",


### PR DESCRIPTION
## Before this PR
The repos where in whatever order they happened to be in from `gcv-maven-repositories.xml` this was often not ideal as the most common repos where not first and all the others had to be checked first

## After this PR
Now we use a comparator to give preference to repo urls that contain `release` or `jar` and give less preference to repos with `internal` or `dist`

Tests where also added for the reader class
==COMMIT_MSG==
Order repositories based on url contents 
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

