### PR TITLE
Plugin upgrades do not require the user to restart there IDE

### DIFF
--- a/changelog/@unreleased/pr-72.v2.yml
+++ b/changelog/@unreleased/pr-72.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: dynamic reload plugin
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/72

--- a/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/gradle-consistent-versions-idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin url="https://github.com/palantir/gradle-consistent-versions-idea-plugin">
+<idea-plugin url="https://github.com/palantir/gradle-consistent-versions-idea-plugin" require-restart="false">
   <id>gradle-consistent-versions</id>
   <name>gradle-consistent-versions</name>
   <vendor url="https://github.com/palantir/gradle-consistent-versions-idea-plugin">


### PR DESCRIPTION
## Before this PR
Whenever we upgraded the plugin users were required to do a full restart of there IDE

## After this PR
Now the plugin should be able to upgrade without forcing the user to restart there IDE as we have set `requires-restart=false`

All checks have been ran to ensure dynamic upgrading works see https://plugins.jetbrains.com/docs/intellij/dynamic-plugins.html?from=jetbrains.org

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Plugin upgrades do not require the user to restart there IDE 
==COMMIT_MSG==

## Possible downsides?
There is no easy way to run this as part of gradle, previously https://github.com/JetBrains/inspection-plugin would have worked but the project has now been deprecated in favour of https://www.jetbrains.com/qodana/ which is too heavy handed for this plugin. This means we have no automated ways of ensuring that the checks are ran in the future
