### PR TITLE
Prevent projects with the same start to there name writing locks on each other

### DIFF
--- a/changelog/@unreleased/pr-75.v2.yml
+++ b/changelog/@unreleased/pr-75.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Prevent projects with the same start to there name writing locks on
+    each other
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/75

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsFileListener.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionPropsFileListener.java
@@ -65,7 +65,7 @@ public final class VersionPropsFileListener implements AsyncFileListener {
                 .filter(Project::isInitialized)
                 .filter(Predicate.not(ComponentManager::isDisposed))
                 .filter(project -> versionPropsEvents.stream()
-                        .anyMatch(event -> event.getPath().startsWith(project.getBasePath())
+                        .anyMatch(event -> event.getPath().startsWith(project.getBasePath() + "/")
                                 && !isFileMalformed(project, event.getFile())))
                 .toList();
 


### PR DESCRIPTION
## Before this PR
If two projects started with the same name and are open e.g. `example` and `example-longer` then `startsWith` would match both projects if `example-longer`'s versions.props was edited. 

As the event path`/Volumes/git/example-longer/versions.props` starts with both `/Volumes/git/example` and `/Volumes/git/example-longer` this would cause the wrong project to refresh

## After this PR
We now append a '/' to the starts with search to ensure only the correct project is matched.

Now `/Volumes/git/example-longer/versions.props` does not start with `/Volumes/git/example/` so `example` will not be refreshed

==COMMIT_MSG==
Prevent projects with the same start to there name writing locks on each other
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

