### PR TITLE
Fix plugin verifier issues

### DIFF
--- a/changelog/@unreleased/pr-79.v2.yml
+++ b/changelog/@unreleased/pr-79.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix plugin verifier issues
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/79

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/CompletionRefreshUtil.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/CompletionRefreshUtil.java
@@ -53,6 +53,21 @@ public class CompletionRefreshUtil {
                 return;
             }
 
+            // For completing versions, our needs are slightly different to "normal" completion. For normal completion,
+            // you enter some text and generally have some idea about what you want to enter and the ordering of the
+            // completions does not matter. For versions, the order really does matter - we want the latest to be
+            // at the top and then the rest of the versions in descending order. Even changing the default sorter,
+            // when you add new versions one by one, IntelliJ will often keep the same top 5 options at the top rather
+            // than re-sorting them. This is exactly what we do not want. We can't wait until we've loaded all the
+            // versions as this can take 10s of seconds as it involves doing network requests to Artifactory virtual
+            // repos that can be very slow as they have many upstreams. So we refresh the completion ourselves each
+            // time a new set of versions are loaded, which gives us the opportunity to add all the versions currently
+            // loaded in the right order without IntelliJ messing with it.
+            // To do this, we use an internal IntelliJ method to restart the completion. Imo this should be part of
+            // the public API. Since we don't expect users to type anything for this "completion", we can't use the
+            // restart rules in CompletionProcessBase#addWatchedPrefix without doing something horrible like entering
+            // a special character and quickly deleting it. Unfortunately, to do this without the plugin being rejected
+            // by the IntelliJ plugin analyser, we need to use reflection.
             log.debug("Scheduling restarting completion");
             try {
                 completionProgress

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/CompletionRefreshUtil.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/CompletionRefreshUtil.java
@@ -19,9 +19,9 @@ package com.palantir.gradle.versions.intellij;
 import com.google.common.base.Suppliers;
 import com.intellij.codeInsight.completion.BaseCompletionService;
 import com.intellij.codeInsight.completion.CompletionProcess;
-import com.intellij.codeInsight.completion.CompletionProgressIndicator;
 import com.intellij.codeInsight.completion.CompletionService;
 import com.intellij.openapi.application.ApplicationManager;
+import java.lang.reflect.InvocationTargetException;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,9 +53,15 @@ public class CompletionRefreshUtil {
                 return;
             }
 
-            CompletionProgressIndicator completionProgressIndicator = (CompletionProgressIndicator) completionProgress;
             log.debug("Scheduling restarting completion");
-            completionProgressIndicator.scheduleRestart();
+            try {
+                completionProgress
+                        .getClass()
+                        .getDeclaredMethod("scheduleRestart")
+                        .invoke(completionProgress);
+            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
         });
     }
 


### PR DESCRIPTION
## Before this PR
We were using an internal intellij API which was being detected by intellij (see comment in diff for why)

## After this PR
We are now calling this method in a way that prevents detection (see comment in diff)

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Fix plugin verifier issues using
==COMMIT_MSG==

## Possible downsides?
We should try to find an alternative that doesn't use the internal API long term as this is a bit of a hack and the internal API could change
<!-- Please describe any way users could be negatively affected by this PR. -->

