### PR TITLE
Allow for . character in package name during lexing

### DIFF
--- a/changelog/@unreleased/pr-87.v2.yml
+++ b/changelog/@unreleased/pr-87.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Allow for . character in package name during lexing
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/87

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionProps.flex
@@ -42,17 +42,18 @@ VERSION=[^= \n\f#]+
 COLON=[:]
 EQUALS=[=]
 DOT=[.]
-IDENTIFIER = [^.:=\ \n\t\f]+
+GROUP_PART = [^.:=\ \n\t\f]+
+NAME_KEY = [^:=\ \n\t\f]+
 COMMENT=("#")[^\r\n]*
 
 %%
 
 <YYINITIAL> {WHITE_SPACE}*{COMMENT}              { return VersionPropsTypes.COMMENT; }
-<YYINITIAL> {IDENTIFIER}                         { return VersionPropsTypes.GROUP_PART; }
+<YYINITIAL> {GROUP_PART}                         { return VersionPropsTypes.GROUP_PART; }
 <YYINITIAL> {DOT}                                { return VersionPropsTypes.DOT; }
 <YYINITIAL> {COLON}                              { yybegin(WAITING_NAME); return VersionPropsTypes.COLON; }
 
-<WAITING_NAME> {IDENTIFIER}                      { yybegin(WAITING_VERSION); return VersionPropsTypes.NAME_KEY; }
+<WAITING_NAME> {NAME_KEY}                        { yybegin(WAITING_VERSION); return VersionPropsTypes.NAME_KEY; }
 
 <WAITING_VERSION> {WHITE_SPACE}+                 { return TokenType.WHITE_SPACE; }
 <WAITING_VERSION> {EQUALS}                       { return VersionPropsTypes.EQUALS; }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsLexerTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/VersionPropsLexerTests.java
@@ -68,6 +68,7 @@ public class VersionPropsLexerTests extends LightJavaCodeInsightFixtureTestCase5
                 "has.spaces.around : colon = 1",
                 "has.no.spaces.around:equals=1",
                 "has.loads.of.spaces:around   =   equals",
+                "this.is.a.test:with.dots.in.the.name = 1",
                 "    # comment after spaces");
 
         JavaCodeInsightTestFixture fixture = getFixture();

--- a/gradle-consistent-versions-idea-plugin/src/test/resources/lexerTests/93f5eb3eb699df3086a76de218626686409862745b5ac17aba383549f81708e4
+++ b/gradle-consistent-versions-idea-plugin/src/test/resources/lexerTests/93f5eb3eb699df3086a76de218626686409862745b5ac17aba383549f81708e4
@@ -1,0 +1,19 @@
+this.is.a.test:with.dots.in.the.name = 1
+VersionPropsTokenType.GROUP_PART this
+VersionPropsTokenType.DOT .
+VersionPropsTokenType.GROUP_PART is
+VersionPropsTokenType.DOT .
+VersionPropsTokenType.GROUP_PART a
+VersionPropsTokenType.DOT .
+VersionPropsTokenType.GROUP_PART test
+DEPENDENCY_GROUP this.is.a.test
+VersionPropsTokenType.COLON :
+VersionPropsTokenType.NAME_KEY with.dots.in.the.name
+DEPENDENCY_NAME with.dots.in.the.name
+WHITE_SPACE  
+VersionPropsTokenType.EQUALS =
+WHITE_SPACE  
+VersionPropsTokenType.VERSION 1
+DEPENDENCY_VERSION 1
+PROPERTY this.is.a.test:with.dots.in.the.name = 1
+FILE this.is.a.test:with.dots.in.the.name = 1


### PR DESCRIPTION
## Before this PR
We where using the same regex for group parts and package names which did not include the . character, this break lexing if the package name includes a .

## After this PR
We now use separate regex's so that . can be included in the package name
==COMMIT_MSG==
Allow for . character in package name during lexing
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

