### PR TITLE
log contents and only require version field

### DIFF
--- a/changelog/@unreleased/pr-104.v2.yml
+++ b/changelog/@unreleased/pr-104.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: log contents and only require version field
+  links:
+  - https://github.com/palantir/gradle-consistent-versions-idea-plugin/pull/104

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Metadata.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/Metadata.java
@@ -32,16 +32,6 @@ import org.immutables.value.Value;
 interface Metadata {
     @Value.Parameter
     @JacksonXmlElementWrapper(useWrapping = false)
-    @JacksonXmlProperty(localName = "groupId")
-    String groupId();
-
-    @Value.Parameter
-    @JacksonXmlElementWrapper(useWrapping = false)
-    @JacksonXmlProperty(localName = "artifactId")
-    String artifactId();
-
-    @Value.Parameter
-    @JacksonXmlElementWrapper(useWrapping = false)
     @JacksonXmlProperty(localName = "versioning")
     Versioning versioning();
 

--- a/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionExplorer.java
+++ b/gradle-consistent-versions-idea-plugin/src/main/java/com/palantir/gradle/versions/intellij/VersionExplorer.java
@@ -104,6 +104,7 @@ public final class VersionExplorer {
             return parseVersionsFromContent(metadata);
         } catch (Exception e) {
             log.error("Failed to parse maven-metadata.xml", e);
+            log.error("Full content: \n", content);
         }
         return Collections.emptySet();
     }

--- a/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryExplorerTests.java
+++ b/gradle-consistent-versions-idea-plugin/src/test/java/com/palantir/gradle/versions/intellij/RepositoryExplorerTests.java
@@ -33,11 +33,7 @@ public class RepositoryExplorerTests {
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = Metadata.builder()
-                .groupId("com.example")
-                .artifactId("example-artifact")
-                .versioning(versioning)
-                .build();
+        Metadata metadata = Metadata.builder().versioning(versioning).build();
 
         Set<DependencyVersion> versions = VersionExplorer.parseVersionsFromContent(metadata);
 
@@ -57,11 +53,7 @@ public class RepositoryExplorerTests {
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = Metadata.builder()
-                .groupId("com.example")
-                .artifactId("example-artifact")
-                .versioning(versioning)
-                .build();
+        Metadata metadata = Metadata.builder().versioning(versioning).build();
 
         Set<DependencyVersion> versions = VersionExplorer.parseVersionsFromContent(metadata);
 
@@ -94,11 +86,7 @@ public class RepositoryExplorerTests {
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = Metadata.builder()
-                .groupId("com.example")
-                .artifactId("example-artifact")
-                .versioning(versioning)
-                .build();
+        Metadata metadata = Metadata.builder().versioning(versioning).build();
 
         Set<DependencyVersion> versions = VersionExplorer.parseVersionsFromContent(metadata);
 
@@ -118,11 +106,7 @@ public class RepositoryExplorerTests {
                 .lastUpdated("unimportant")
                 .build();
 
-        Metadata metadata = Metadata.builder()
-                .groupId("com.example")
-                .artifactId("example-artifact")
-                .versioning(versioning)
-                .build();
+        Metadata metadata = Metadata.builder().versioning(versioning).build();
 
         Set<DependencyVersion> versions = VersionExplorer.parseVersionsFromContent(metadata);
 


### PR DESCRIPTION
## Before this PR
Sometimes if a project had been open for a few days then revisited the following error would occur:

```
Failed to parse maven-metadata.xml

com.fasterxml.jackson.databind.exc.ValueInstantiationException: Cannot construct instance of `com.palantir.gradle.versions.intellij.ImmutableMetadata`, problem: Cannot build Metadata, some of required attributes are not set [groupId, artifactId, versioning]
 at [Source: (StringReader); line: 9, column: 1]
	at com.fasterxml.jackson.databind.exc.ValueInstantiationException.from(ValueInstantiationException.java:47)
	at com.fasterxml.jackson.databind.DeserializationContext.instantiationException(DeserializationContext.java:2014)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.wrapAsJsonMappingException(StdValueInstantiator.java:598)
	at com.fasterxml.jackson.databind.deser.std.StdValueInstantiator.rewrapCtorProblem(StdValueInstantiator.java:621)
```

This is very confusing as the `parseVersionsFromContent` method is only called when a user is editing the version in `versions.props` and this was happening when the project was opened. 

## After this PR
If the parsing fails now the content that is being parsed it logged so we can attempt to determine where this is being ran from

I have also removed the unused fields from the metadata object

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
log contents and only require version field
==COMMIT_MSG==

